### PR TITLE
Implement `strict` configuration im `Mapper`

### DIFF
--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -14,7 +14,6 @@ def get(
     only_if: ConditionalCheck | None = None,
     drop_level: DROP | None = None,
     flatten: bool = False,
-    dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = jmespath_dsl,
 ) -> Any:
     """
     Gets a value from the source dictionary using a `.` syntax.
@@ -38,6 +37,7 @@ def get(
     # Grab context from `Mapper` classes (if relevant)
     mapper_state = _get_global_mapper_config()
     strict = mapper_state.strict if mapper_state else None
+    dsl_fn = mapper_state.custom_dsl_fn if mapper_state else jmespath_dsl
 
     res = _nested_get(source, key, default, dsl_fn)
     _enforce_strict(res, strict, key)

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -1,7 +1,9 @@
+import traceback
 from typing import Any, Callable, Iterable, Sequence
 
+from .globs import SharedMapperState, _Global_Mapper_State_Dict
 from .lib.types import DROP, KEEP, ApplyFunc, ConditionalCheck
-from .lib.util import flatten_list, jmespath_dsl
+from .lib.util import encode_stack_trace, flatten_list, jmespath_dsl
 
 
 def get(
@@ -12,7 +14,7 @@ def get(
     only_if: ConditionalCheck | None = None,
     drop_level: DROP | None = None,
     flatten: bool = False,
-    dsl_fn: Callable[[dict[str, Any], Any], Any] = jmespath_dsl,
+    dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = jmespath_dsl,
 ) -> Any:
     """
     Gets a value from the source dictionary using a `.` syntax.
@@ -33,18 +35,19 @@ def get(
     - `flatten`: Use to flatten the final result (e.g. nested lists)
     - `dsl_fn`: Use to specify a DSL to "grab" data besides JMESPath
     """
-    # Handle case where source is a list
-    if isinstance(source, list):
-        source = {"_": source}
-        key = "_" + key
+    # Grab context from `Mapper` classes (if relevant)
+    mapper_state = _get_global_mapper_config()
+    strict = mapper_state.strict if mapper_state else None
 
     res = _nested_get(source, key, default, dsl_fn)
+    _enforce_strict(res, strict, key)
 
     if flatten and isinstance(res, list):
         res = flatten_list(res)
 
     if res is not None and only_if:
         res = res if only_if(res) else None
+        _enforce_strict(res, strict, key)
 
     if res is not None and apply:
         if not isinstance(apply, Iterable):
@@ -52,6 +55,7 @@ def get(
         for fn in apply:
             try:
                 res = fn(res)
+                _enforce_strict(res, strict, key)
             except Exception as e:
                 raise RuntimeError(f"`apply` call {fn} failed for value: {res} at key: {key}, {e}")
             if res is None:
@@ -63,11 +67,28 @@ def get(
     return res
 
 
+def _enforce_strict(res: Any, strict: bool | None, key: str) -> None:
+    # TODO: Have way of distinguishing failed get vs deliberate `None`
+    if strict and res is None:
+        raise ValueError(f"Strict mode: found `None` for key: {key}")
+
+
+def _get_global_mapper_config() -> SharedMapperState | None:
+    curr_trace = traceback.format_stack()
+    # Iterate through all mappers, and check stack trace with key str
+    for m_id, sms in _Global_Mapper_State_Dict.items():
+        if len(curr_trace) <= sms._trace_len:
+            continue
+        if m_id == encode_stack_trace(curr_trace[: sms._trace_len]):
+            return sms
+    return None
+
+
 def _nested_get(
-    source: dict[str, Any],
+    source: dict[str, Any] | list[Any],
     key: str | Any,
     default: Any = None,
-    dsl_fn: Callable[[dict[str, Any], Any], Any] = jmespath_dsl,
+    dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = jmespath_dsl,
 ) -> Any:
     """
     Expects `.`-delimited string and tries to get the item in the dict.
@@ -78,6 +99,7 @@ def _nested_get(
     If you use a custom `dsl_fn`, then logic is entrusted to that function (wgpcgr).
     """
     # Assume `key: str`. If not, then trust the custom `dsl_fn` to handle it
+    # Handle tuple syntax (if they ask for a tuple, return a tuple)
     if isinstance(key, str) and ("(" in key and ")" in key):
         key = key.replace("(", "[").replace(")", "]")
         res = dsl_fn(source, key)

--- a/pydian/globs.py
+++ b/pydian/globs.py
@@ -25,8 +25,7 @@ V = TypeVar("V")
 
 class ImmutableDict(dict, Generic[K, V]):
     """
-    Global
-    `dict` that can receive new items, and inserted items are immutable
+    Global `dict` that can receive new items, and inserted items are immutable
     """
 
     def __setitem__(self, key, value):

--- a/pydian/globs.py
+++ b/pydian/globs.py
@@ -1,0 +1,52 @@
+"""
+This module contains _shared_ global state which is managed by the `Mapper` and used by `get`
+
+Some notes:
+- Python globals are at the module-level, and persist per interpeted session
+- Python currently uses the GIL which means each process has different globals
+    - This means all expected `Mapper` config needs to run within a given process
+- When developing, naming conventions should be followed
+"""
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+
+@dataclass(frozen=True)
+class SharedMapperState:
+    _trace_len: int
+    strict: bool
+    # TODO: add dsl function
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class ImmutableDict(dict, Generic[K, V]):
+    """
+    Global
+    `dict` that can receive new items, and inserted items are immutable
+    """
+
+    def __setitem__(self, key, value):
+        if not isinstance(key, str):
+            raise ValueError(f"Key type needs to be `str`, got: {type(value)} {value}")
+        if not isinstance(value, SharedMapperState):
+            raise ValueError(
+                f"Value type needs to be `SharedMapperState`, got: {type(value)} {value}"
+            )
+        if key in self:
+            raise ValueError(
+                f"Key {key} already exists and ImmutableDict doesn't allow updating keys."
+            )
+        super().__setitem__(key, value)
+
+    def update(self, *args, **kwargs):
+        raise ValueError("ImmutableDict doesn't allow updates.")
+
+    def __delitem__(self, key):
+        raise ValueError("ImmutableDict doesn't allow deletion of keys.")
+
+
+_Global_Mapper_State_Dict: ImmutableDict[str, SharedMapperState] = ImmutableDict()

--- a/pydian/globs.py
+++ b/pydian/globs.py
@@ -9,14 +9,14 @@ Some notes:
 """
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 
 @dataclass(frozen=True)
 class SharedMapperState:
     _trace_len: int
     strict: bool
-    # TODO: add dsl function
+    custom_dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any]
 
 
 K = TypeVar("K")

--- a/pydian/lib/util.py
+++ b/pydian/lib/util.py
@@ -1,3 +1,4 @@
+import base64
 from collections.abc import Collection
 from itertools import chain
 from typing import Any, TypeVar
@@ -5,15 +6,6 @@ from typing import Any, TypeVar
 import jmespath
 
 DL = TypeVar("DL", dict[str, Any], list[Any])
-
-
-def jmespath_dsl(source: dict[str, Any], key: str):
-    """
-    Specifies a DSL (domain-specific language) to use when running `get`
-
-    Here, we redefine the `jmespath.search` to be consistent with argument ordering
-    """
-    return jmespath.search(key, source)
 
 
 def remove_empty_values(input: DL) -> DL:
@@ -76,3 +68,17 @@ def flatten_list(res: list[list[Any]]) -> list[Any]:
         # Handle nested case
         res = flatten_list(res)
     return res
+
+
+def jmespath_dsl(source: dict[str, Any] | list[Any], key: str):
+    """
+    Specifies a DSL (domain-specific language) to use when running `get`
+
+    Here, we redefine the `jmespath.search` to be consistent with argument ordering
+    """
+    return jmespath.search(key, source)
+
+
+def encode_stack_trace(stack_trace: list[str]) -> str:
+    # Encode the stack trace (into bytes), then save the byte representation as a str (second `decode`)
+    return base64.b64encode(bytes(("".join(stack_trace)), "utf-8")).decode("utf-8")

--- a/pydian/mapper.py
+++ b/pydian/mapper.py
@@ -1,8 +1,10 @@
+import traceback
 from typing import Any
 
 from .dicts import drop_keys, impute_enum_values
+from .globs import SharedMapperState, _Global_Mapper_State_Dict
 from .lib.types import DROP, KEEP, MappingFunc
-from .lib.util import get_keys_containing_class, remove_empty_values
+from .lib.util import encode_stack_trace, get_keys_containing_class, remove_empty_values
 
 
 class Mapper:
@@ -10,14 +12,37 @@ class Mapper:
         self,
         map_fn: MappingFunc,
         remove_empty: bool = True,
+        strict: bool = False,
     ) -> None:
         self.map_fn = map_fn
         self.remove_empty = remove_empty
+        self.strict = strict
+        self.global_mapper_call_id: str | None = None
+        self.global_mapper_call_level: int | None = None
 
-    def __call__(self, source: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    def _register_mapper_call_id(self) -> None:
+        """
+        A `mapper_call_id` is uniquely identified by the current stack trace.
+          This is so subsequence function calls can identify it is part of the mapper.
+        """
+        # The stack trace, excluding this level and `__call__`
+        curr_trace = traceback.format_stack()[:-2]
+        self.global_mapper_call_id = encode_stack_trace(curr_trace)
+        self.global_mapper_call_level = len(curr_trace)
+        # Update global state
+        _Global_Mapper_State_Dict[self.global_mapper_call_id] = SharedMapperState(
+            _trace_len=self.global_mapper_call_level, strict=self.strict
+        )
+        return None
+
+    def __call__(self, source: dict[str, Any], **kwargs) -> dict[str, Any]:
         """
         Calls `map_fn` and then performs postprocessing into the result dict.
         """
+        # If global mapper ID is not in config dict, then add it + hash stack trace
+        if not self.global_mapper_call_id:
+            self._register_mapper_call_id()
+
         res = self.map_fn(source, **kwargs)
 
         # Handle any DROP-flagged values

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import pydash
-
 import pydian.partials as p
 from pydian import Mapper, get
 from pydian.dicts import drop_keys
@@ -28,21 +26,6 @@ def test_get(simple_data: dict[str, Any]) -> None:
         "CASE_nested_as_list": [source["data"]["patient"]["active"]],
         "CASE_modded": source["data"]["patient"]["id"] + "_modified",
     }
-
-
-def test_get_new_dsl(simple_data: dict[str, Any]) -> None:
-    source = simple_data
-
-    # Use the pydash.get DSL which allows for array keys, but doesn't use "*"
-    assert (
-        get(source, "list_data[0].patient.id", dsl_fn=pydash.get)
-        == source["list_data"][0]["patient"]["id"]
-    )
-    assert (
-        get(source, ["list_data", 0, "patient", "id"], dsl_fn=pydash.get)
-        == source["list_data"][0]["patient"]["id"]
-    )
-    assert get(source, "list_data[*].patient.id", dsl_fn=pydash.get) == None
 
 
 def test_get_index(simple_data: dict[str, Any]) -> None:

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -105,3 +105,29 @@ def test_keep_empty_value() -> None:
         "static_val": "Def",
         "empty_list": [],
     }
+
+
+def test_strict(simple_data: dict[str, Any]) -> None:
+    source = simple_data
+
+    def mapping(m: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "CASE_parent_keep": {
+                "CASE_curr_drop": {
+                    "a": DROP.THIS_OBJECT,
+                    "b": "someValue",
+                },
+                "CASE_curr_keep": {"id": get(m, "data.patient.id")},
+            },
+            "CASE_missing": get(m, "key.nope.not.there"),
+        }
+
+    strict_mapper = Mapper(mapping, strict=True)
+    with pytest.raises(ValueError) as exc_info:
+        strict_mapper(source)
+
+    mapper = Mapper(mapping, strict=False)
+
+    assert mapper(source) == {
+        "CASE_parent_keep": {"CASE_curr_keep": {"id": get(source, "data.patient.id")}}
+    }

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pydash
 import pytest
 
 from pydian import Mapper, get
@@ -130,4 +131,25 @@ def test_strict(simple_data: dict[str, Any]) -> None:
 
     assert mapper(source) == {
         "CASE_parent_keep": {"CASE_curr_keep": {"id": get(source, "data.patient.id")}}
+    }
+
+
+def test_custom_dsl_fn(simple_data: dict[str, Any]) -> None:
+    source = simple_data
+
+    def mapping(m: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "CASE_pydash_1a": get(m, "list_data[0].patient.id"),
+            # This should succeed with a custom DSL
+            "CASE_pydash_1b": get(m, ["list_data", 0, "patient", "id"]),
+            # This should fail with a custom DSL
+            "CASE_pydian_syntax": get(m, "list_data[*].patient.id"),
+        }
+
+    custom_dsl_mapper = Mapper(mapping, remove_empty=False, custom_dsl_fn=pydash.get)
+
+    assert custom_dsl_mapper(source) == {
+        "CASE_pydash_1a": source["list_data"][0]["patient"]["id"],
+        "CASE_pydash_1b": source["list_data"][0]["patient"]["id"],
+        "CASE_pydian_syntax": None,
     }


### PR DESCRIPTION
Closes #8 

If `Mapper(..., strict=True)`, then for calls specific to that `Mapper` a `None` result will return a `ValueError`. This can be helpful in debugging or in prod environments when these middle states matter more