### PR TITLE
Handle case where source dict explicitly contains `None`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,37 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## How To Reproduce
+<!-- E.g. Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Additional context
+<!--
+**Screenshots**: If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Desktop context:**
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+**Smartphone context:**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
+ -->
+
+
+
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,19 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Requested feature
+<!-- **Describe the solution you'd like**
+A clear and concise description of what you want to happen. -->
+
+### Alternatives considered
+<!-- **Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered. -->
+-
+
+## Additional context
+<!-- **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-**Closes Issue: **
-
-# _Title_
+**Closes Issue**:
 
 ## Background
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -164,29 +164,29 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.12.4"
+version = "3.13.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.12.4-py3-none-any.whl", hash = "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4"},
-    {file = "filelock-3.12.4.tar.gz", hash = "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"},
+    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
+    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "sphinx (>=7.1.2)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3)", "diff-cover (>=7.7)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "pytest-timeout (>=2.1)"]
-typing = ["typing-extensions (>=4.7.1)"]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "identify"
-version = "2.5.30"
+version = "2.5.31"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.30-py2.py3-none-any.whl", hash = "sha256:afe67f26ae29bab007ec21b03d4114f41316ab9dd15aa8736a167481e108da54"},
-    {file = "identify-2.5.30.tar.gz", hash = "sha256:f302a4256a15c849b91cfcdcec052a8ce914634b2f77ae87dad29cd749f2d88d"},
+    {file = "identify-2.5.31-py2.py3-none-any.whl", hash = "sha256:90199cb9e7bd3c5407a9b7e81b4abec4bb9d249991c79439ec8af740afc6293d"},
+    {file = "identify-2.5.31.tar.gz", hash = "sha256:7736b3c7a28233637e3c36550646fc6389bedd74ae84cb788200cc8e2dd60b75"},
 ]
 
 [package.extras]
@@ -388,13 +388,13 @@ dev = ["Sphinx", "black", "build", "coverage", "docformatter", "flake8", "flake8
 
 [[package]]
 name = "pytest"
-version = "7.4.2"
+version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
-    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
 ]
 
 [package.dependencies]
@@ -525,13 +525,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.24.5"
+version = "20.24.6"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.24.5-py3-none-any.whl", hash = "sha256:b80039f280f4919c77b30f1c23294ae357c4c8701042086e3fc005963e4e537b"},
-    {file = "virtualenv-20.24.5.tar.gz", hash = "sha256:e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752"},
+    {file = "virtualenv-20.24.6-py3-none-any.whl", hash = "sha256:520d056652454c5098a00c0f073611ccbea4c79089331f60bf9d7ba247bb7381"},
+    {file = "virtualenv-20.24.6.tar.gz", hash = "sha256:02ece4f56fbf939dbbc33c0715159951d6bf14aaf5457b092e4548e1382455af"},
 ]
 
 [package.dependencies]

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -70,7 +70,6 @@ def get(
 def _enforce_strict(
     res: Any, strict: bool | None, key: str, source: dict[str, Any] | list[Any]
 ) -> None:
-    # TODO: Have way of distinguishing failed get vs deliberate `None`
     if strict and res is None:
         # Check if value is deliberately `None`, otherwise return error
         tokenized_keypath = _get_tokenized_keypath(key)

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -40,14 +40,14 @@ def get(
     dsl_fn = mapper_state.custom_dsl_fn if mapper_state else default_dsl
 
     res = _nested_get(source, key, default, dsl_fn)
-    _enforce_strict(res, strict, key)
+    _enforce_strict(res, strict, key, source)
 
     if flatten and isinstance(res, list):
         res = flatten_list(res)
 
     if res is not None and only_if:
         res = res if only_if(res) else None
-        _enforce_strict(res, strict, key)
+        _enforce_strict(res, strict, key, source)
 
     if res is not None and apply:
         if not isinstance(apply, Iterable):
@@ -55,7 +55,7 @@ def get(
         for fn in apply:
             try:
                 res = fn(res)
-                _enforce_strict(res, strict, key)
+                _enforce_strict(res, strict, key, source)
             except Exception as e:
                 raise RuntimeError(f"`apply` call {fn} failed for value: {res} at key: {key}, {e}")
             if res is None:
@@ -67,10 +67,30 @@ def get(
     return res
 
 
-def _enforce_strict(res: Any, strict: bool | None, key: str) -> None:
+def _enforce_strict(
+    res: Any, strict: bool | None, key: str, source: dict[str, Any] | list[Any]
+) -> None:
     # TODO: Have way of distinguishing failed get vs deliberate `None`
     if strict and res is None:
-        raise ValueError(f"Strict mode: found `None` for key: {key}")
+        # Check if value is deliberately `None`, otherwise return error
+        tokenized_keypath = _get_tokenized_keypath(key)
+        nested_val: Any = source
+        MISSING_VAL_INDICATOR = "__NOTFOUND__"
+        for k in tokenized_keypath:
+            if nested_val == MISSING_VAL_INDICATOR:
+                break
+            match k:
+                case "*":
+                    # TODO: handle list unwraps - here we'll just stop checking
+                    nested_val = MISSING_VAL_INDICATOR
+                case _:
+                    nested_val = (
+                        nested_val[k]
+                        if (isinstance(k, int) or k in nested_val)
+                        else MISSING_VAL_INDICATOR
+                    )
+        if nested_val is not None:
+            raise ValueError(f"_Strict mode_: invalid key: {key}")
 
 
 def _get_global_mapper_config() -> SharedMapperState | None:

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Iterable, Sequence
 
 from .globs import SharedMapperState, _Global_Mapper_State_Dict
 from .lib.types import DROP, KEEP, ApplyFunc, ConditionalCheck
-from .lib.util import encode_stack_trace, flatten_list, jmespath_dsl
+from .lib.util import default_dsl, encode_stack_trace, flatten_list
 
 
 def get(
@@ -37,7 +37,7 @@ def get(
     # Grab context from `Mapper` classes (if relevant)
     mapper_state = _get_global_mapper_config()
     strict = mapper_state.strict if mapper_state else None
-    dsl_fn = mapper_state.custom_dsl_fn if mapper_state else jmespath_dsl
+    dsl_fn = mapper_state.custom_dsl_fn if mapper_state else default_dsl
 
     res = _nested_get(source, key, default, dsl_fn)
     _enforce_strict(res, strict, key)
@@ -88,7 +88,7 @@ def _nested_get(
     source: dict[str, Any] | list[Any],
     key: str | Any,
     default: Any = None,
-    dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = jmespath_dsl,
+    dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = default_dsl,
 ) -> Any:
     """
     Expects `.`-delimited string and tries to get the item in the dict.

--- a/pydian/lib/util.py
+++ b/pydian/lib/util.py
@@ -70,7 +70,7 @@ def flatten_list(res: list[list[Any]]) -> list[Any]:
     return res
 
 
-def jmespath_dsl(source: dict[str, Any] | list[Any], key: str):
+def default_dsl(source: dict[str, Any] | list[Any], key: str):
     """
     Specifies a DSL (domain-specific language) to use when running `get`
 

--- a/pydian/mapper.py
+++ b/pydian/mapper.py
@@ -5,9 +5,9 @@ from .dicts import drop_keys, impute_enum_values
 from .globs import SharedMapperState, _Global_Mapper_State_Dict
 from .lib.types import DROP, KEEP, MappingFunc
 from .lib.util import (
+    default_dsl,
     encode_stack_trace,
     get_keys_containing_class,
-    jmespath_dsl,
     remove_empty_values,
 )
 
@@ -18,7 +18,7 @@ class Mapper:
         map_fn: MappingFunc,
         remove_empty: bool = True,
         strict: bool = False,
-        custom_dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = jmespath_dsl,
+        custom_dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = default_dsl,
     ) -> None:
         self.map_fn = map_fn
         self.remove_empty = remove_empty

--- a/pydian/partials.py
+++ b/pydian/partials.py
@@ -16,6 +16,7 @@ def get(
     apply: ApplyFunc | Iterable[ApplyFunc] | None = None,
     only_if: ConditionalCheck | None = None,
     drop_level: DROP | None = None,
+    flatten: bool | None = None,
 ):
     """
     Partial wrapper around the Pydian `get` function
@@ -26,6 +27,7 @@ def get(
         "apply": apply,
         "only_if": only_if,
         "drop_level": drop_level,
+        "flatten": flatten,
     }
     return partial(pydian.get, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydian"
-version = "0.2.3"
+version = "0.2.4"
 description = "Library for pythonic data interchange"
 authors = ["Eric Pan <eric.pan@stanford.edu>"]
 


### PR DESCRIPTION
**Closes Issue**:  #12 

## Background

Sometimes, a `None`/`null` contained within source data has semantic meaning, and it's important to respect that instead of assuming that it should be ignored + lumped in to the failure case. This PR 

## Design (high-level)

The `get` function uses an `enforce_strict(...)` call. At each of those calls, manually get into the keypath (as opposed to using a DSL) and verify that the underlying value is `None`

## Other notes

This makes assumptions about the DSL keypath and probably means the "custom" DSL isn't that custom. In fact, maybe it shouldn't be custom (unless can make guarantee elsewhere), could be misleading... (+ There should be one-- and preferably only one --obvious way to do it.")