### PR TITLE
Add `strict` flag for `get`

### DIFF
--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -14,6 +14,7 @@ def get(
     only_if: ConditionalCheck | None = None,
     drop_level: DROP | None = None,
     flatten: bool = False,
+    strict: bool | None = None,
 ) -> Any:
     """
     Gets a value from the source dictionary using a `.` syntax.
@@ -32,11 +33,11 @@ def get(
     - `only_if`: Use to conditionally decide if the result should be kept + `apply`-ed.
     - `drop_level`: Use to specify conditional dropping if get results in None.
     - `flatten`: Use to flatten the final result (e.g. nested lists)
-    - `dsl_fn`: Use to specify a DSL to "grab" data besides JMESPath
     """
     # Grab context from `Mapper` classes (if relevant)
     mapper_state = _get_global_mapper_config()
-    strict = mapper_state.strict if mapper_state else None
+    # For `strict`, prefer Mapper setting or take local setting
+    strict = (mapper_state.strict if mapper_state else None) or strict
     dsl_fn = mapper_state.custom_dsl_fn if mapper_state else default_dsl
 
     res = _nested_get(source, key, default, dsl_fn)

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -24,7 +24,7 @@ def get(
      - Use `.` to chain gets
      - Index and slice into lists, e.g. `[0]`, `[-1]`, `[:1]`, etc.
      - Iterate through a list using `[*]`
-     - Get multiple items using `[firstKey,secondKey]` syntax (outputs as a list)
+     - Get multiple items using `(firstKey,secondKey)` syntax (outputs as a tuple)
        The keys within the tuple can also be chained with `.`
 
     Optional param notes:
@@ -33,6 +33,7 @@ def get(
     - `only_if`: Use to conditionally decide if the result should be kept + `apply`-ed.
     - `drop_level`: Use to specify conditional dropping if get results in None.
     - `flatten`: Use to flatten the final result (e.g. nested lists)
+    - `strict`: Use to throw `ValueError` instead of returning `None` (also available at `Mapper`-level)
     """
     # Grab context from `Mapper` classes (if relevant)
     mapper_state = _get_global_mapper_config()

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+import pytest
+
 import pydian.partials as p
-from pydian import Mapper, get
+from pydian import get
 from pydian.dicts import drop_keys
 
 
@@ -176,3 +178,13 @@ def test_get_nested_key_tuple(nested_data: dict[str, Any]) -> None:
     assert get(source, "data[*].patient.dicts[*].[num, inner.msg]") == [
         [[obj["num"], obj["inner"]["msg"]] for obj in d["patient"]["dicts"]] for d in source["data"]
     ]
+
+
+def test_get_strict(nested_data: dict[str, Any]) -> None:
+    source = nested_data
+
+    # Simple key example
+    MISSING_KEY = "some.key.nope.notthere"
+    with pytest.raises(ValueError) as exc_info:
+        get(source, MISSING_KEY, strict=True)
+    assert get(source, MISSING_KEY) == None


### PR DESCRIPTION
Closes #17 

## Background
The `strict` flag was configured just at the `Mapper`-level. While this is useful, it doesn't allow for more specific workflows for `get`

## Design (high-level)
- Add extra parameter for `get`, default `strict=None`
  - If mapper-level config is specified, try that first. If it isn't True, then take `get`-level

## Other notes
