### PR TITLE
Remove custom DSL function

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -370,23 +370,6 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
-name = "pydash"
-version = "7.0.6"
-description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pydash-7.0.6-py3-none-any.whl", hash = "sha256:10e506935953fde4b0d6fe21a88e17783cd1479256ae96f285b5f89063b4efd6"},
-    {file = "pydash-7.0.6.tar.gz", hash = "sha256:7d9df7e9f36f2bbb08316b609480e7c6468185473a21bdd8e65dda7915565a26"},
-]
-
-[package.dependencies]
-typing-extensions = ">=3.10,<4.6.0 || >4.6.0"
-
-[package.extras]
-dev = ["Sphinx", "black", "build", "coverage", "docformatter", "flake8", "flake8-black", "flake8-bugbear", "flake8-isort", "furo", "importlib-metadata (<5)", "invoke", "isort", "mypy", "pylint", "pytest", "pytest-cov", "pytest-mypy-testing", "sphinx-autodoc-typehints", "tox", "twine", "wheel"]
-
-[[package]]
 name = "pytest"
 version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
@@ -546,4 +529,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "92fd00fe11d58596eee1ccc63709c398beba964257041de263fb93627f167dc5"
+content-hash = "97ae8c6d30bc66a9f317767fc30949ea8b43fb770711a06c64041e14969246fa"

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -39,9 +39,8 @@ def get(
     mapper_state = _get_global_mapper_config()
     # For `strict`, prefer Mapper setting or take local setting
     strict = (mapper_state.strict if mapper_state else None) or strict
-    dsl_fn = mapper_state.custom_dsl_fn if mapper_state else default_dsl
 
-    res = _nested_get(source, key, default, dsl_fn)
+    res = _nested_get(source, key, default)
     _enforce_strict(res, strict, key, source)
 
     if flatten and isinstance(res, list):

--- a/pydian/globs.py
+++ b/pydian/globs.py
@@ -16,7 +16,6 @@ from typing import Any, Callable, Generic, TypeVar
 class SharedMapperState:
     _trace_len: int
     strict: bool
-    custom_dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any]
 
 
 K = TypeVar("K")

--- a/pydian/lib/util.py
+++ b/pydian/lib/util.py
@@ -74,7 +74,7 @@ def default_dsl(source: dict[str, Any] | list[Any], key: str):
     """
     Specifies a DSL (domain-specific language) to use when running `get`
 
-    Here, we redefine the `jmespath.search` to be consistent with argument ordering
+    Here, we redefine the `jmespath.search` to be consistent with argument ordering in the repo
     """
     return jmespath.search(key, source)
 

--- a/pydian/mapper.py
+++ b/pydian/mapper.py
@@ -4,12 +4,7 @@ from typing import Any, Callable
 from .dicts import drop_keys, impute_enum_values
 from .globs import SharedMapperState, _Global_Mapper_State_Dict
 from .lib.types import DROP, KEEP, MappingFunc
-from .lib.util import (
-    default_dsl,
-    encode_stack_trace,
-    get_keys_containing_class,
-    remove_empty_values,
-)
+from .lib.util import encode_stack_trace, get_keys_containing_class, remove_empty_values
 
 
 class Mapper:
@@ -18,12 +13,10 @@ class Mapper:
         map_fn: MappingFunc,
         remove_empty: bool = True,
         strict: bool = False,
-        custom_dsl_fn: Callable[[dict[str, Any] | list[Any], Any], Any] = default_dsl,
     ) -> None:
         self.map_fn = map_fn
         self.remove_empty = remove_empty
         self.strict = strict
-        self.custom_dsl_fn = custom_dsl_fn
         self.global_mapper_call_id: str | None = None
         self.global_mapper_call_level: int | None = None
 
@@ -40,7 +33,6 @@ class Mapper:
         _Global_Mapper_State_Dict[self.global_mapper_call_id] = SharedMapperState(
             _trace_len=self.global_mapper_call_level,
             strict=self.strict,
-            custom_dsl_fn=self.custom_dsl_fn,
         )
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ mypy = "^0.982"
 pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
 pre-commit = "^2.20.0"
-pydash = "^7.0.6"
 
 [tool.black]
 line-length = 100

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import pydash
 import pytest
 
 from pydian import Mapper, get
@@ -192,24 +191,3 @@ def test_script_deliberate_none() -> None:
 
     with pytest.raises(ValueError) as exc_info:
         err_mapper(source)
-
-
-def test_custom_dsl_fn(simple_data: dict[str, Any]) -> None:
-    source = simple_data
-
-    def mapping(d: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "CASE_pydash_1a": get(d, "list_data[0].patient.id"),
-            # This should succeed with a custom DSL
-            "CASE_pydash_1b": get(d, ["list_data", 0, "patient", "id"]),
-            # This should fail with a custom DSL
-            "CASE_pydian_syntax": get(d, "list_data[*].patient.id"),
-        }
-
-    custom_dsl_mapper = Mapper(mapping, remove_empty=False, custom_dsl_fn=pydash.get)
-
-    assert custom_dsl_mapper(source) == {
-        "CASE_pydash_1a": source["list_data"][0]["patient"]["id"],
-        "CASE_pydash_1b": source["list_data"][0]["patient"]["id"],
-        "CASE_pydian_syntax": None,
-    }


### PR DESCRIPTION
Closes #16 

## Background
The ability to add a custom DSL function didn't account for other parts of the framework -- opting to remove it and rework it in later if it makes sense


## Design (high-level)
- Remove `custom_dsl_fn` from Mapper state
  - Remove corresponding calls in the codebase

## Other notes
