### PR TITLE
Add dataframe support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-**Closes Issue**:
+Closes
 
 ## Background
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -311,6 +311,47 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "numpy"
+version = "1.26.1"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af"},
+    {file = "numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575"},
+    {file = "numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244"},
+    {file = "numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67"},
+    {file = "numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2"},
+    {file = "numpy-1.26.1-cp310-cp310-win32.whl", hash = "sha256:d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297"},
+    {file = "numpy-1.26.1-cp310-cp310-win_amd64.whl", hash = "sha256:d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab"},
+    {file = "numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a"},
+    {file = "numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9"},
+    {file = "numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3"},
+    {file = "numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974"},
+    {file = "numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c"},
+    {file = "numpy-1.26.1-cp311-cp311-win32.whl", hash = "sha256:b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b"},
+    {file = "numpy-1.26.1-cp311-cp311-win_amd64.whl", hash = "sha256:3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53"},
+    {file = "numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f"},
+    {file = "numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24"},
+    {file = "numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e"},
+    {file = "numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124"},
+    {file = "numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"},
+    {file = "numpy-1.26.1-cp312-cp312-win32.whl", hash = "sha256:af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66"},
+    {file = "numpy-1.26.1-cp312-cp312-win_amd64.whl", hash = "sha256:9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7"},
+    {file = "numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e"},
+    {file = "numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617"},
+    {file = "numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e"},
+    {file = "numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908"},
+    {file = "numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5"},
+    {file = "numpy-1.26.1-cp39-cp39-win32.whl", hash = "sha256:d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104"},
+    {file = "numpy-1.26.1-cp39-cp39-win_amd64.whl", hash = "sha256:59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2"},
+    {file = "numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668"},
+    {file = "numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42"},
+    {file = "numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f"},
+    {file = "numpy-1.26.1.tar.gz", hash = "sha256:c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -320,6 +361,74 @@ files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.1.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:24057459f19db9ebb02984c6fdd164a970b31a95f38e4a49cf7615b36a1b532c"},
+    {file = "pandas-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6cf8fcc8a63d333970b950a7331a30544cf59b1a97baf0a7409e09eafc1ac38"},
+    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ae6ffbd9d614c20d028c7117ee911fc4e266b4dca2065d5c5909e401f8ff683"},
+    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff794eeb7883c5aefb1ed572e7ff533ae779f6c6277849eab9e77986e352688"},
+    {file = "pandas-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02954e285e8e2f4006b6f22be6f0df1f1c3c97adbb7ed211c6b483426f20d5c8"},
+    {file = "pandas-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:5b40c9f494e1f27588c369b9e4a6ca19cd924b3a0e1ef9ef1a8e30a07a438f43"},
+    {file = "pandas-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08d287b68fd28906a94564f15118a7ca8c242e50ae7f8bd91130c362b2108a81"},
+    {file = "pandas-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bbd98dcdcd32f408947afdb3f7434fade6edd408c3077bbce7bd840d654d92c6"},
+    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e90c95abb3285d06f6e4feedafc134306a8eced93cb78e08cf50e224d5ce22e2"},
+    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52867d69a54e71666cd184b04e839cff7dfc8ed0cd6b936995117fdae8790b69"},
+    {file = "pandas-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8d0382645ede2fde352da2a885aac28ec37d38587864c0689b4b2361d17b1d4c"},
+    {file = "pandas-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:65177d1c519b55e5b7f094c660ed357bb7d86e799686bb71653b8a4803d8ff0d"},
+    {file = "pandas-2.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5aa6b86802e8cf7716bf4b4b5a3c99b12d34e9c6a9d06dad254447a620437931"},
+    {file = "pandas-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d594e2ce51b8e0b4074e6644758865dc2bb13fd654450c1eae51201260a539f1"},
+    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3223f997b6d2ebf9c010260cf3d889848a93f5d22bb4d14cd32638b3d8bba7ad"},
+    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4944dc004ca6cc701dfa19afb8bdb26ad36b9bed5bcec617d2a11e9cae6902"},
+    {file = "pandas-2.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3f76280ce8ec216dde336e55b2b82e883401cf466da0fe3be317c03fb8ee7c7d"},
+    {file = "pandas-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:7ad20d24acf3a0042512b7e8d8fdc2e827126ed519d6bd1ed8e6c14ec8a2c813"},
+    {file = "pandas-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:021f09c15e1381e202d95d4a21ece8e7f2bf1388b6d7e9cae09dfe27bd2043d1"},
+    {file = "pandas-2.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7f12b2de0060b0b858cfec0016e7d980ae5bae455a1746bfcc70929100ee633"},
+    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c166b9bb27c1715bed94495d9598a7f02950b4749dba9349c1dd2cbf10729d"},
+    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25c9976c17311388fcd953cb3d0697999b2205333f4e11e669d90ff8d830d429"},
+    {file = "pandas-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:851b5afbb0d62f6129ae891b533aa508cc357d5892c240c91933d945fff15731"},
+    {file = "pandas-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:e78507adcc730533619de07bfdd1c62b2918a68cd4419ea386e28abf7f6a1e5c"},
+    {file = "pandas-2.1.2.tar.gz", hash = "sha256:52897edc2774d2779fbeb6880d2cfb305daa0b1a29c16b91f531a18918a6e0f3"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.1"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.6)", "SQLAlchemy (>=1.4.36)", "beautifulsoup4 (>=4.11.1)", "bottleneck (>=1.3.4)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=0.8.1)", "fsspec (>=2022.05.0)", "gcsfs (>=2022.05.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.8.0)", "matplotlib (>=3.6.1)", "numba (>=0.55.2)", "numexpr (>=2.8.0)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pandas-gbq (>=0.17.5)", "psycopg2 (>=2.9.3)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.5)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "pyxlsb (>=1.0.9)", "qtpy (>=2.2.0)", "s3fs (>=2022.05.0)", "scipy (>=1.8.1)", "tables (>=3.7.0)", "tabulate (>=0.8.10)", "xarray (>=2022.03.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)", "zstandard (>=0.17.0)"]
+aws = ["s3fs (>=2022.05.0)"]
+clipboard = ["PyQt5 (>=5.15.6)", "qtpy (>=2.2.0)"]
+compression = ["zstandard (>=0.17.0)"]
+computation = ["scipy (>=1.8.1)", "xarray (>=2022.03.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pyxlsb (>=1.0.9)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)"]
+feather = ["pyarrow (>=7.0.0)"]
+fss = ["fsspec (>=2022.05.0)"]
+gcp = ["gcsfs (>=2022.05.0)", "pandas-gbq (>=0.17.5)"]
+hdf5 = ["tables (>=3.7.0)"]
+html = ["beautifulsoup4 (>=4.11.1)", "html5lib (>=1.1)", "lxml (>=4.8.0)"]
+mysql = ["SQLAlchemy (>=1.4.36)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.8.10)"]
+parquet = ["pyarrow (>=7.0.0)"]
+performance = ["bottleneck (>=1.3.4)", "numba (>=0.55.2)", "numexpr (>=2.8.0)"]
+plot = ["matplotlib (>=3.6.1)"]
+postgresql = ["SQLAlchemy (>=1.4.36)", "psycopg2 (>=2.9.3)"]
+spss = ["pyreadstat (>=1.1.5)"]
+sql-other = ["SQLAlchemy (>=1.4.36)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.8.0)"]
 
 [[package]]
 name = "pathspec"
@@ -421,6 +530,31 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2023.3.post1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -496,6 +630,17 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -515,6 +660,17 @@ python-versions = ">=3.8"
 files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
 ]
 
 [[package]]
@@ -539,5 +695,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "314f6bf501eed6a4cc39945b90d490707341fdd3725d015d58e86c4016405130"
+python-versions = ">=3.10,<3.13"
+content-hash = "b9a402af953a1fe96386a05d71fe055bf6303486f8fdf813ba252716155ea84d"

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -13,7 +13,7 @@ def select(
     default: Any = None,
     apply: ApplyFunc
     | Iterable[ApplyFunc]
-    | dict[str, ApplyFunc | Iterable[ApplyFunc]]
+    | dict[str, ApplyFunc | Iterable[ApplyFunc] | Any]
     | None = None,
     only_if: ConditionalCheck | None = None,
     consume: bool = False,
@@ -41,11 +41,10 @@ def select(
         res = source[parsed_col_list]
         if res.empty:
             res = default
-    # TODO: Case where some valid columns, and some invalid?
+        elif consume:
+            source.drop(columns=parsed_col_list, inplace=True)
     except KeyError:
         res = default
-    if consume:
-        source.drop(columns=parsed_col_list, inplace=True)
 
     if res is not None and only_if:
         res = res if only_if(res) else None

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -86,7 +86,7 @@ def left_join(
 
 
 def inner_join(
-    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str], consume: bool = False
+    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str]
 ) -> pd.DataFrame | None:
     """
     Applies an inner join
@@ -96,15 +96,7 @@ def inner_join(
     except KeyError:
         return None
 
-    res = first.merge(second, how="inner", on=on, indicator=True)
-
-    # Only consume if a join happened
-    if consume and not res.empty:
-        # Create a boolean mask indicating whether each row in `first` is also present in `second`
-        fmask = first.isin(second.to_dict(orient="list")).all(axis=1)
-        smask = second.isin(first.to_dict(orient="list")).all(axis=1)
-        first.drop(first[fmask].index, inplace=True)
-        second.drop(second[smask].index, inplace=True)
+    res = first.merge(second, how="inner", on=on, indicator=False)
 
     return res if not res.empty else None
 

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -1,0 +1,65 @@
+from typing import Any, Callable, Iterable
+
+import pandas as pd
+
+from .lib.types import ApplyFunc, ConditionalCheck
+
+
+def select(
+    source: pd.DataFrame,
+    key: str,
+    default: Any = None,
+    apply: ApplyFunc | Iterable[ApplyFunc]
+    # | dict[str, ApplyFunc | Iterable[ApplyFunc]]
+    | None = None,
+    only_if: ConditionalCheck | None = None,
+    consume: bool = False,
+) -> pd.DataFrame | None:
+    """
+    Gets a subset of a DataFrame. The following conditions apply:
+    1. Columns must have names, otherwise an exception will be raised
+    2. Index names will be ignored: a row is identified by its 0-indexed position
+
+    PURE FUNCTION: `source` is not modified. This makes memory management important
+
+    `key` notes:
+    - Strings represent columns, int represent rows
+
+
+    - `consume`: Remove the original dataframe from memory
+    """
+    _check_assumptions(source)
+
+    # Get columns from syntax
+    parsed_col_list = key.replace(" ", "").split(",")
+    if parsed_col_list == ["*"]:
+        parsed_col_list = source.columns
+    try:
+        res = source[parsed_col_list]
+        if res.empty:
+            res = default
+    except KeyError:
+        res = default
+
+    if res is not None and only_if:
+        res = res if only_if(res) else None
+
+    if res is not None and apply:
+        if not isinstance(apply, Iterable):
+            apply = (apply,)
+        for fn in apply:
+            try:
+                res = fn(res)
+            except Exception as e:
+                raise RuntimeError(f"`apply` call {fn} failed for value: {res} at key: {key}, {e}")
+            if res is None:
+                break
+
+    return res
+
+
+def _check_assumptions(source: pd.DataFrame) -> None:
+    ## Check for column names that are `str`
+    col_types = {type(c) for c in source.columns}
+    if col_types != {str}:
+        raise ValueError(f"Column headers need to be `str`, got: {col_types}")

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable
+from typing import Any, Iterable
 
 import pandas as pd
 
@@ -29,7 +29,7 @@ def select(
     - Strings represent columns, int represent rows
 
 
-    - `consume`: Remove the original dataframe from memory
+    - `consume`: Remove the original data from the dataframe from memory
     """
     _check_assumptions(source)
 
@@ -41,8 +41,11 @@ def select(
         res = source[parsed_col_list]
         if res.empty:
             res = default
+    # TODO: Case where some valid columns, and some invalid?
     except KeyError:
         res = default
+    if consume:
+        source.drop(columns=parsed_col_list, inplace=True)
 
     if res is not None and only_if:
         res = res if only_if(res) else None

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -27,24 +27,14 @@ def select(
 
     `key` notes:
     - Strings represent columns, int represent rows
+    - _Order matters_
 
 
     - `consume`: Remove the original data from the dataframe from memory
     """
     _check_assumptions(source)
 
-    # Get columns from syntax
-    parsed_col_list = key.replace(" ", "").split(",")
-    if parsed_col_list == ["*"]:
-        parsed_col_list = source.columns
-    try:
-        res = source[parsed_col_list]
-        if res.empty:
-            res = default
-        elif consume:
-            source.drop(columns=parsed_col_list, inplace=True)
-    except KeyError:
-        res = default
+    res = _nested_select(source, key, default, consume)
 
     if res is not None and only_if:
         res = res if only_if(res) else None
@@ -60,6 +50,62 @@ def select(
             res = _try_apply(res, apply, key)  # type: ignore
 
     return res
+
+
+def left_join(
+    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str], consume: bool = False
+) -> pd.DataFrame | None:
+    """
+    Applies a left join
+
+    A left join resulting in no change or an empty database results in None
+    """
+    try:
+        _pre_merge_checks(first, second, on)
+    except KeyError:
+        return None
+
+    res = first.merge(second, how="left", on=on, indicator=True)
+
+    # If there were no matches, then return `None`
+    if select(res, "_merge", apply=[p.iloc(None, 0), set]) == {"left_only"}:
+        return None
+
+    # Only consume if there was a change
+    if consume:
+        # Only drop rows that were included in the left join
+        # TODO: MAKE SELECT SYNTAX MAGIC MASKING! This doesn't work (yet)
+        matched_rows = select(res, ",".join(on.replace("_merge", "_merge[?_merge == 'both']")))  # type: ignore
+        # TODO: making assumption on indices here, is this a problem?
+        second.drop(index=matched_rows.index, inplace=True)  # type: ignore
+
+    res.drop("_merge", axis=1, inplace=True)
+
+    return res if not res.empty else None
+
+
+def inner_join(
+    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str], consume: bool = False
+) -> pd.DataFrame | None:
+    """
+    Applies an inner join
+    """
+    try:
+        _pre_merge_checks(first, second, on)
+    except KeyError:
+        return None
+
+    res = first.merge(second, how="inner", on=on, indicator=True)
+
+    # Only consume if a join happened
+    if consume and not res.empty:
+        # Create a boolean mask indicating whether each row in `first` is also present in `second`
+        fmask = first.isin(second.to_dict(orient="list")).all(axis=1)
+        smask = second.isin(first.to_dict(orient="list")).all(axis=1)
+        first.drop(first[fmask].index, inplace=True)
+        second.drop(second[smask].index, inplace=True)
+
+    return res if not res.empty else None
 
 
 def _check_assumptions(source: pd.DataFrame) -> None:
@@ -80,4 +126,32 @@ def _try_apply(source: Any, apply: ApplyFunc | Iterable[ApplyFunc], key: str) ->
             raise RuntimeError(f"`apply` call {fn} failed for value: {res} with key: {key}, {e}")
         if res is None:
             break
+    return res
+
+
+def _pre_merge_checks(first: pd.DataFrame, second: pd.DataFrame, on: str | list[str]) -> None:
+    # If _any_ of the provided indices aren't there, return `None`
+    if isinstance(on, str):
+        on = [on]
+    for c in on:
+        if not (c in first.columns and c in second.columns):
+            raise KeyError(f"Proposed key {c} is not in either column!")
+
+
+def _nested_select(
+    source: pd.DataFrame, key: str, default: Any, consume: bool
+) -> pd.DataFrame | Any:
+    res = None
+    # Get columns from syntax
+    parsed_col_list = key.replace(" ", "").split(",")
+    if parsed_col_list == ["*"]:
+        parsed_col_list = source.columns
+    try:
+        res = source[parsed_col_list]
+        if res.empty:
+            res = default
+        elif consume:
+            source.drop(columns=parsed_col_list, inplace=True)
+    except KeyError:
+        res = default
     return res

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -8,7 +8,7 @@ from .lib.util import default_dsl, encode_stack_trace, flatten_list
 
 def get(
     source: dict[str, Any] | list[Any],
-    key: str | Any,
+    key: str,
     default: Any = None,
     apply: ApplyFunc | Iterable[ApplyFunc] | None = None,
     only_if: ConditionalCheck | None = None,

--- a/pydian/globs.py
+++ b/pydian/globs.py
@@ -9,7 +9,7 @@ Some notes:
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, TypeVar
+from typing import Generic, TypeVar
 
 
 @dataclass(frozen=True)

--- a/pydian/mapper.py
+++ b/pydian/mapper.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Any, Callable
+from typing import Any
 
 from .dicts import drop_keys, impute_enum_values
 from .globs import SharedMapperState, _Global_Mapper_State_Dict

--- a/pydian/partials.py
+++ b/pydian/partials.py
@@ -167,10 +167,13 @@ DataFrame Wrappers
 import pandas as pd
 
 DF: TypeAlias = pd.DataFrame
+DFRow: TypeAlias = pd.Series
 
 
-def where(func: ApplyFunc) -> ApplyFunc | Callable[[DF], DF]:
-    return lambda df: df.where(func)
+def replace_where(
+    func: ApplyFunc | Callable[[DFRow], Any], with_val: Any
+) -> ApplyFunc | Callable[[DF], DF]:
+    return lambda df: df.where(func, other=with_val)
 
 
 def order_by(s: str, ascending: bool = True) -> ApplyFunc | Callable[[DF], DF]:
@@ -187,3 +190,15 @@ def group_by(s: str | list[str]) -> ApplyFunc | Callable[[DF], dict[str | tuple,
 
 def distinct() -> ApplyFunc | Callable[[DF], DF]:
     return lambda df: df.drop_duplicates(inplace=False)
+
+
+def iloc(ridx: int | None = None, cidx: int | None = None) -> ApplyFunc | Callable[[DF], DF]:
+    has_row_idx, has_col_idx = ridx is not None, cidx is not None
+    if not (has_row_idx or has_col_idx):
+        raise ValueError(f"At least one of ridx and cidx need to be given, got: {ridx} {cidx}")
+    res = lambda df: df.iloc[ridx, cidx]
+    if has_row_idx:
+        res = lambda df: df.iloc[ridx, :]
+    elif has_col_idx:
+        res = lambda df: df.iloc[:, cidx]
+    return res

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,9 @@ description = "Library for pythonic data interchange"
 authors = ["Eric Pan <eric.pan@stanford.edu>"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<3.13"
 jmespath = "^1.0.1"
+pandas = "^2.1.2"
 
 [tool.poetry.dev-dependencies]
 black = "^23.10.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from typing import Any
 
+import pandas as pd
 import pytest
+
 
 def simple_list() -> list[Any]:
     return [
@@ -9,9 +11,22 @@ def simple_list() -> list[Any]:
         {"patient": {"id": "ghi789", "active": False}},
     ]
 
+
 @pytest.fixture(scope="function")
 def list_data() -> list[Any]:
     return simple_list()
+
+
+@pytest.fixture(scope="function")
+def simple_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "a": [0, 1, 2, 3, 4, 5],
+            "b": ["q", "w", "e", "r", "t", "y"],
+            "c": [True, False, True, False, False, True],
+            "d": [pd.NA, None, None, pd.NA, pd.NA, None],
+        }
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -144,9 +144,34 @@ def test_left_join(simple_dataframe: pd.DataFrame) -> None:
     # }))
 
 
-# TODO
 def test_inner_join(simple_dataframe: pd.DataFrame) -> None:
-    ...
+    # Split the simple_dataframe into two DataFrames for joining
+    df1 = simple_dataframe[["a", "b"]]
+    df2 = simple_dataframe[["b", "c"]]
+
+    # Expected result of the inner join
+    expected_result = pd.DataFrame(
+        {
+            "a": [0, 1, 2, 3, 4, 5],
+            "b": ["q", "w", "e", "r", "t", "y"],
+            "c": [True, False, True, False, False, True],
+        }
+    )
+
+    # Perform the inner join
+    result = inner_join(df1, df2, on="b")
+
+    # Check that the result matches the expected result
+    pd.testing.assert_frame_equal(result, expected_result)
+
+    # Test with non-existent column
+    result = inner_join(df1, df2, on="non_existent_column")
+    assert result is None, f"Expected None, but got {result}"
+
+    # Test with empty result
+    df1_empty = df1.head(0)
+    result = inner_join(df1_empty, df2, on="b")
+    assert result is None, f"Expected None, but got {result}"
 
 
 def test_insert(simple_dataframe: pd.DataFrame) -> None:

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -99,7 +99,6 @@ def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
     assert "c" not in source_two.columns
 
 
-# TODO
 def test_left_join(simple_dataframe: pd.DataFrame) -> None:
     source = simple_dataframe
 
@@ -111,7 +110,6 @@ def test_left_join(simple_dataframe: pd.DataFrame) -> None:
     )
 
     # `None` cases
-    # # A key is missing from either df
     assert left_join(source, df_right, on="d") is None, "Expected None since `d` is not in right"
     assert left_join(source, df_right, on="e") is None, "Expected None since `e` is not in left"
     assert left_join(source, df_right, on="f") is None, "Expected None since `f` is not in either"

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -1,0 +1,65 @@
+import pandas as pd
+
+import pydian.partials as p
+from pydian.dataframes import select
+
+
+def test_select(simple_dataframe: pd.DataFrame) -> None:
+    source = simple_dataframe
+
+    assert select(source, "a").equals(source[["a"]])  #  type: ignore
+    assert select(source, "a, b").equals(source[["a", "b"]])  #  type: ignore
+    assert select(source, "*").equals(source)  #  type: ignore
+
+    assert select(source, "non_existant_col", apply=p.equals("thing")) is None
+    assert select(source, "non_existant_col", default="thing", apply=p.equals("thing")) == True
+    assert (
+        select(
+            source,
+            "non_existant_col",
+            default="",
+            apply=p.equals("thing"),
+            only_if=p.equals("thing"),
+        )
+        is None
+    )
+
+    # WHERE
+    assert select(  #  type: ignore
+        source,
+        "*",
+        apply=p.where(lambda r: r["a"] % 2 == 0),
+    ).equals(source.where(lambda r: r["a"] % 2 == 0))
+
+    # ORDER BY
+    assert select(source, "*", apply=p.order_by("a", False)).equals(  #  type: ignore
+        source.sort_values("a", ascending=False)
+    )  #  type: ignore
+
+    # GROUP BY
+    assert select(source, "*", apply=p.group_by("a")) == source.groupby("a").groups
+
+    # "First n"
+    assert select(source, "*", apply=p.keep(5)).equals(source.head(5))  #  type: ignore
+
+    # Distinct
+    assert select(source, "*", apply=p.distinct()).equals(source.drop_duplicates())  #  type: ignore
+
+
+# TODO
+def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
+    ...
+
+
+# TODO
+def test_select_polars(simple_dataframe: pd.DataFrame) -> None:
+    ...
+
+
+# TODO
+def test_join(simple_dataframe: pd.DataFrame) -> None:
+    # Pandas and Pandas
+    # Pandas and Polars
+    # Polars and Pandas
+    # Polars and Polars
+    ...

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -46,6 +46,19 @@ def test_select(simple_dataframe: pd.DataFrame) -> None:
     assert select(source, "*", apply=p.distinct()).equals(source.drop_duplicates())  #  type: ignore
 
 
+def test_select_apply_map(simple_dataframe) -> None:
+    source = simple_dataframe
+    apply_map = {"a": [p.multiply(2), p.add(1)], "b": [str.upper], "d": p.equivalent(None)}
+
+    comp_df = simple_dataframe.copy()
+    comp_df["a"] *= 2
+    comp_df["a"] += 1
+    comp_df["b"] = comp_df["b"].apply(str.upper)
+    comp_df["d"] = comp_df["d"].apply(lambda v: v is None)
+
+    assert select(source, "*", apply=apply_map).equals(comp_df)  #  type: ignore
+
+
 # TODO
 def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
     ...

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import pandas as pd
 
 import pydian.partials as p
-from pydian.dataframes import inner_join, left_join, select
+from pydian.dataframes import inner_join, insert, left_join, select
 
 
 def test_select(simple_dataframe: pd.DataFrame) -> None:
@@ -175,7 +175,39 @@ def test_inner_join(simple_dataframe: pd.DataFrame) -> None:
 
 
 def test_insert(simple_dataframe: pd.DataFrame) -> None:
-    ...
+    rows_to_insert = [{"a": 6, "b": "u", "c": False, "d": pd.NA}]
+    expected_data = {
+        "a": [0, 1, 2, 3, 4, 5, 6],
+        "b": ["q", "w", "e", "r", "t", "y", "u"],
+        "c": [True, False, True, False, False, True, False],
+        "d": [pd.NA, None, None, pd.NA, pd.NA, None, pd.NA],
+    }
+
+    # Test basic insert functionality
+    result = insert(simple_dataframe, rows_to_insert)
+    pd.DataFrame(expected_data).equals(result)
+
+    # Test consume functionality
+    rows_df = pd.DataFrame(rows_to_insert)
+    result = insert(simple_dataframe, rows_df, consume=True)
+    pd.DataFrame(expected_data).equals(result)
+    assert rows_df.empty, f"Expected rows_df to be empty, but got {rows_df}"
+
+    # Test default value functionality
+    rows_to_insert_default = [{"a": 7, "b": "i"}]
+    expected_data_default = {
+        "a": [0, 1, 2, 3, 4, 5, 7],
+        "b": ["q", "w", "e", "r", "t", "y", "i"],
+        "c": [True, False, True, False, False, True, pd.NA],
+        "d": [pd.NA, None, None, pd.NA, pd.NA, None, pd.NA],
+    }
+    result = insert(simple_dataframe, rows_to_insert_default)
+    pd.DataFrame(expected_data_default).equals(result)
+
+    # Test incompatible columns
+    incompatible_rows = [{"e": 8}]
+    result = insert(simple_dataframe, incompatible_rows)
+    assert result is None, f"Expected None, but got {result}"
 
 
 def test_alter(simple_dataframe: pd.DataFrame) -> None:

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -11,6 +11,8 @@ def test_select(simple_dataframe: pd.DataFrame) -> None:
     assert select(source, "a, b").equals(source[["a", "b"]])  #  type: ignore
     assert select(source, "*").equals(source)  #  type: ignore
 
+    # TODO: Case where some valid columns, and some invalid?
+
     assert select(source, "non_existant_col", apply=p.equals("thing")) is None
     assert select(source, "non_existant_col", default="thing", apply=p.equals("thing")) == True
     assert (
@@ -59,9 +61,15 @@ def test_select_apply_map(simple_dataframe) -> None:
     assert select(source, "*", apply=apply_map).equals(comp_df)  #  type: ignore
 
 
-# TODO
 def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
-    ...
+    source = simple_dataframe
+
+    init_mem_usage_by_column = source.memory_usage(deep=True)
+    assert source[["a"]].equals(select(source, "a", consume=True))
+    assert "a" not in source.columns
+    assert sum(source.memory_usage(deep=True)) < sum(init_mem_usage_by_column)
+
+    # TODO: Add cases
 
 
 # TODO

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -1,9 +1,10 @@
 from copy import deepcopy
 
 import pandas as pd
+import pytest
 
 import pydian.partials as p
-from pydian.dataframes import inner_join, insert, left_join, select
+from pydian.dataframes import alter, inner_join, insert, left_join, select
 
 
 def test_select(simple_dataframe: pd.DataFrame) -> None:
@@ -211,4 +212,22 @@ def test_insert(simple_dataframe: pd.DataFrame) -> None:
 
 
 def test_alter(simple_dataframe: pd.DataFrame) -> None:
-    ...
+    # Test the drop_cols feature of the alter function
+    drop_result: pd.DataFrame = alter(simple_dataframe, drop_cols="a,c")
+    assert "a" not in drop_result.columns
+    assert "c" not in drop_result.columns
+
+    # Test the overwrite_cols feature of the alter function
+    overwrite_result: pd.DataFrame = alter(
+        simple_dataframe, overwrite_cols={"b": ["z", "x", "c", "v", "b", "n"]}
+    )
+    assert all(overwrite_result["b"] == ["z", "x", "c", "v", "b", "n"])
+
+    # Test the add_cols feature of the alter function
+    add_result: pd.DataFrame = alter(simple_dataframe, add_cols={"e": [6, 7, 8, 9, 10, 11]})
+    assert "e" in add_result.columns
+    assert all(add_result["e"] == [6, 7, 8, 9, 10, 11])
+
+    # Test the alter function with invalid input
+    with pytest.raises(ValueError):
+        alter(simple_dataframe, add_cols="not a dictionary")  # type: ignore

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -7,14 +7,13 @@ from pydian.dataframes import select
 def test_select(simple_dataframe: pd.DataFrame) -> None:
     source = simple_dataframe
 
-    assert select(source, "a").equals(source[["a"]])  #  type: ignore
-    assert select(source, "a, b").equals(source[["a", "b"]])  #  type: ignore
-    assert select(source, "*").equals(source)  #  type: ignore
-
-    # TODO: Case where some valid columns, and some invalid?
+    assert source[["a"]].equals(select(source, "a"))
+    assert source[["a", "b"]].equals(select(source, "a, b"))
+    assert source.equals(select(source, "*"))
 
     assert select(source, "non_existant_col", apply=p.equals("thing")) is None
     assert select(source, "non_existant_col", default="thing", apply=p.equals("thing")) == True
+    assert select(source, "non_existant_col", consume=True) is None
     assert (
         select(
             source,
@@ -26,29 +25,35 @@ def test_select(simple_dataframe: pd.DataFrame) -> None:
         is None
     )
 
+    # A single non-existant column will cause the entire operation to fail and return None
+    #   Most of the times, we expect columns to be persistent (i.e. no "optional" cases)
+    assert select(source, "a, non_existant_col") is None
+
     # WHERE
-    assert select(  #  type: ignore
-        source,
-        "*",
-        apply=p.where(lambda r: r["a"] % 2 == 0),
-    ).equals(source.where(lambda r: r["a"] % 2 == 0))
+    assert source.where(lambda r: r["a"] % 2 == 0).equals(
+        select(
+            source,
+            "*",
+            apply=p.where(lambda r: r["a"] % 2 == 0),
+        )
+    )
 
     # ORDER BY
-    assert select(source, "*", apply=p.order_by("a", False)).equals(  #  type: ignore
-        source.sort_values("a", ascending=False)
-    )  #  type: ignore
+    assert source.sort_values("a", ascending=False).equals(
+        select(source, "*", apply=p.order_by("a", False))
+    )
 
     # GROUP BY
-    assert select(source, "*", apply=p.group_by("a")) == source.groupby("a").groups
+    assert source.groupby("a").groups == select(source, "*", apply=p.group_by("a"))
 
     # "First n"
-    assert select(source, "*", apply=p.keep(5)).equals(source.head(5))  #  type: ignore
+    assert source.head(5).equals(select(source, "*", apply=p.keep(5)))
 
     # Distinct
-    assert select(source, "*", apply=p.distinct()).equals(source.drop_duplicates())  #  type: ignore
+    assert source.drop_duplicates().equals(select(source, "*", apply=p.distinct()))
 
 
-def test_select_apply_map(simple_dataframe) -> None:
+def test_select_apply_map(simple_dataframe: pd.DataFrame) -> None:
     source = simple_dataframe
     apply_map = {"a": [p.multiply(2), p.add(1)], "b": [str.upper], "d": p.equivalent(None)}
 
@@ -58,7 +63,7 @@ def test_select_apply_map(simple_dataframe) -> None:
     comp_df["b"] = comp_df["b"].apply(str.upper)
     comp_df["d"] = comp_df["d"].apply(lambda v: v is None)
 
-    assert select(source, "*", apply=apply_map).equals(comp_df)  #  type: ignore
+    assert comp_df.equals(select(source, "*", apply=apply_map))
 
 
 def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
@@ -69,7 +74,14 @@ def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
     assert "a" not in source.columns
     assert sum(source.memory_usage(deep=True)) < sum(init_mem_usage_by_column)
 
-    # TODO: Add cases
+    # Selecting from a missing column will not consume others specified (operation failed)
+    assert select(source, "a, b", consume=True) is None
+    assert "b" in source.columns
+
+    # Selecting multiple columns that are all valid
+    assert source[["b", "c"]].equals(select(source, "b, c", consume=True))
+    assert "b" not in source.columns
+    assert "c" not in source.columns
 
 
 # TODO


### PR DESCRIPTION
**Closes Issue**: #6 

## Background

Pydian aims to be a data manipulation framework, and using Pandas DataFrames is one of the most common use-cases for data manipulation in Python. While Pandas has a comprehensive API, it's hard to navigate through and there's too many ways to do the same thing. While the flexibility is powerful, it is often too cumbersome of a learning curve for a non-trivial amount of users (e.g. at least myself, who uses pandas but not that much!)

## Design (high-level)

Introduce the following operators:
- `select`
- `left_join`
- `inner_join`
- `insert`
- `alter`

All operators are (should be?) pure functions when `consume=False`. The `consume` flag is there to save memory for large datasets and possibly also give additional information (e.g. there's one "master" copy of data being processed at any given point)

## Other notes

Confirm this as the base, then look into other df-related features (e.g. adding pola.rs)