### PR TITLE
Add nested select

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,29 +2,29 @@
 
 [[package]]
 name = "black"
-version = "23.10.1"
+version = "23.11.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:ec3f8e6234c4e46ff9e16d9ae96f4ef69fa328bb4ad08198c8cee45bb1f08c69"},
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:1b917a2aa020ca600483a7b340c165970b26e9029067f019e3755b56e8dd5916"},
-    {file = "black-23.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c74de4c77b849e6359c6f01987e94873c707098322b91490d24296f66d067dc"},
-    {file = "black-23.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:7b4d10b0f016616a0d93d24a448100adf1699712fb7a4efd0e2c32bbb219b173"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b15b75fc53a2fbcac8a87d3e20f69874d161beef13954747e053bca7a1ce53a0"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:e293e4c2f4a992b980032bbd62df07c1bcff82d6964d6c9496f2cd726e246ace"},
-    {file = "black-23.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d56124b7a61d092cb52cce34182a5280e160e6aff3137172a68c2c2c4b76bcb"},
-    {file = "black-23.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:3f157a8945a7b2d424da3335f7ace89c14a3b0625e6593d21139c2d8214d55ce"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:cfcce6f0a384d0da692119f2d72d79ed07c7159879d0bb1bb32d2e443382bf3a"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:33d40f5b06be80c1bbce17b173cda17994fbad096ce60eb22054da021bf933d1"},
-    {file = "black-23.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:840015166dbdfbc47992871325799fd2dc0dcf9395e401ada6d88fe11498abad"},
-    {file = "black-23.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:037e9b4664cafda5f025a1728c50a9e9aedb99a759c89f760bd83730e76ba884"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:7cb5936e686e782fddb1c73f8aa6f459e1ad38a6a7b0e54b403f1f05a1507ee9"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:7670242e90dc129c539e9ca17665e39a146a761e681805c54fbd86015c7c84f7"},
-    {file = "black-23.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed45ac9a613fb52dad3b61c8dea2ec9510bf3108d4db88422bacc7d1ba1243d"},
-    {file = "black-23.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:6d23d7822140e3fef190734216cefb262521789367fbdc0b3f22af6744058982"},
-    {file = "black-23.10.1-py3-none-any.whl", hash = "sha256:d431e6739f727bb2e0495df64a6c7a5310758e87505f5f8cde9ff6c0f2d7e4fe"},
-    {file = "black-23.10.1.tar.gz", hash = "sha256:1f8ce316753428ff68749c65a5f7844631aa18c8679dfd3ca9dc1a289979c258"},
+    {file = "black-23.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dbea0bb8575c6b6303cc65017b46351dc5953eea5c0a59d7b7e3a2d2f433a911"},
+    {file = "black-23.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:412f56bab20ac85927f3a959230331de5614aecda1ede14b373083f62ec24e6f"},
+    {file = "black-23.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d136ef5b418c81660ad847efe0e55c58c8208b77a57a28a503a5f345ccf01394"},
+    {file = "black-23.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:6c1cac07e64433f646a9a838cdc00c9768b3c362805afc3fce341af0e6a9ae9f"},
+    {file = "black-23.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479"},
+    {file = "black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244"},
+    {file = "black-23.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221"},
+    {file = "black-23.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5"},
+    {file = "black-23.11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:45aa1d4675964946e53ab81aeec7a37613c1cb71647b5394779e6efb79d6d187"},
+    {file = "black-23.11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4c44b7211a3a0570cc097e81135faa5f261264f4dfaa22bd5ee2875a4e773bd6"},
+    {file = "black-23.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a9acad1451632021ee0d146c8765782a0c3846e0e0ea46659d7c4f89d9b212b"},
+    {file = "black-23.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:fc7f6a44d52747e65a02558e1d807c82df1d66ffa80a601862040a43ec2e3142"},
+    {file = "black-23.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7f622b6822f02bfaf2a5cd31fdb7cd86fcf33dab6ced5185c35f5db98260b055"},
+    {file = "black-23.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:250d7e60f323fcfc8ea6c800d5eba12f7967400eb6c2d21ae85ad31c204fb1f4"},
+    {file = "black-23.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5133f5507007ba08d8b7b263c7aa0f931af5ba88a29beacc4b2dc23fcefe9c06"},
+    {file = "black-23.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:421f3e44aa67138ab1b9bfbc22ee3780b22fa5b291e4db8ab7eee95200726b07"},
+    {file = "black-23.11.0-py3-none-any.whl", hash = "sha256:54caaa703227c6e0c87b76326d0862184729a69b73d3b7305b6288e1d830067e"},
+    {file = "black-23.11.0.tar.gz", hash = "sha256:4c68855825ff432d197229846f971bc4d6666ce90492e5b02013bcaca4d9ab05"},
 ]
 
 [package.dependencies]
@@ -241,38 +241,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.6.1"
+version = "1.7.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e5012e5cc2ac628177eaac0e83d622b2dd499e28253d4107a08ecc59ede3fc2c"},
-    {file = "mypy-1.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8fbb68711905f8912e5af474ca8b78d077447d8f3918997fecbf26943ff3cbb"},
-    {file = "mypy-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21a1ad938fee7d2d96ca666c77b7c494c3c5bd88dff792220e1afbebb2925b5e"},
-    {file = "mypy-1.6.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b96ae2c1279d1065413965c607712006205a9ac541895004a1e0d4f281f2ff9f"},
-    {file = "mypy-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:40b1844d2e8b232ed92e50a4bd11c48d2daa351f9deee6c194b83bf03e418b0c"},
-    {file = "mypy-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81af8adaa5e3099469e7623436881eff6b3b06db5ef75e6f5b6d4871263547e5"},
-    {file = "mypy-1.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8c223fa57cb154c7eab5156856c231c3f5eace1e0bed9b32a24696b7ba3c3245"},
-    {file = "mypy-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8032e00ce71c3ceb93eeba63963b864bf635a18f6c0c12da6c13c450eedb183"},
-    {file = "mypy-1.6.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4c46b51de523817a0045b150ed11b56f9fff55f12b9edd0f3ed35b15a2809de0"},
-    {file = "mypy-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:19f905bcfd9e167159b3d63ecd8cb5e696151c3e59a1742e79bc3bcb540c42c7"},
-    {file = "mypy-1.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:82e469518d3e9a321912955cc702d418773a2fd1e91c651280a1bda10622f02f"},
-    {file = "mypy-1.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d4473c22cc296425bbbce7e9429588e76e05bc7342da359d6520b6427bf76660"},
-    {file = "mypy-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a0d7d24dfb26729e0a068639a6ce3500e31d6655df8557156c51c1cb874ce7"},
-    {file = "mypy-1.6.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cfd13d47b29ed3bbaafaff7d8b21e90d827631afda134836962011acb5904b71"},
-    {file = "mypy-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:eb4f18589d196a4cbe5290b435d135dee96567e07c2b2d43b5c4621b6501531a"},
-    {file = "mypy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:41697773aa0bf53ff917aa077e2cde7aa50254f28750f9b88884acea38a16169"},
-    {file = "mypy-1.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7274b0c57737bd3476d2229c6389b2ec9eefeb090bbaf77777e9d6b1b5a9d143"},
-    {file = "mypy-1.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbaf4662e498c8c2e352da5f5bca5ab29d378895fa2d980630656178bd607c46"},
-    {file = "mypy-1.6.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bb8ccb4724f7d8601938571bf3f24da0da791fe2db7be3d9e79849cb64e0ae85"},
-    {file = "mypy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:68351911e85145f582b5aa6cd9ad666c8958bcae897a1bfda8f4940472463c45"},
-    {file = "mypy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:49ae115da099dcc0922a7a895c1eec82c1518109ea5c162ed50e3b3594c71208"},
-    {file = "mypy-1.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b27958f8c76bed8edaa63da0739d76e4e9ad4ed325c814f9b3851425582a3cd"},
-    {file = "mypy-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:925cd6a3b7b55dfba252b7c4561892311c5358c6b5a601847015a1ad4eb7d332"},
-    {file = "mypy-1.6.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8f57e6b6927a49550da3d122f0cb983d400f843a8a82e65b3b380d3d7259468f"},
-    {file = "mypy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a43ef1c8ddfdb9575691720b6352761f3f53d85f1b57d7745701041053deff30"},
-    {file = "mypy-1.6.1-py3-none-any.whl", hash = "sha256:4cbe68ef919c28ea561165206a2dcb68591c50f3bcf777932323bc208d949cf1"},
-    {file = "mypy-1.6.1.tar.gz", hash = "sha256:4d01c00d09a0be62a4ca3f933e315455bde83f37f892ba4b08ce92f3cf44bcc1"},
+    {file = "mypy-1.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5da84d7bf257fd8f66b4f759a904fd2c5a765f70d8b52dde62b521972a0a2357"},
+    {file = "mypy-1.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a3637c03f4025f6405737570d6cbfa4f1400eb3c649317634d273687a09ffc2f"},
+    {file = "mypy-1.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b633f188fc5ae1b6edca39dae566974d7ef4e9aaaae00bc36efe1f855e5173ac"},
+    {file = "mypy-1.7.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d6ed9a3997b90c6f891138e3f83fb8f475c74db4ccaa942a1c7bf99e83a989a1"},
+    {file = "mypy-1.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:1fe46e96ae319df21359c8db77e1aecac8e5949da4773c0274c0ef3d8d1268a9"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:df67fbeb666ee8828f675fee724cc2cbd2e4828cc3df56703e02fe6a421b7401"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a79cdc12a02eb526d808a32a934c6fe6df07b05f3573d210e41808020aed8b5d"},
+    {file = "mypy-1.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f65f385a6f43211effe8c682e8ec3f55d79391f70a201575def73d08db68ead1"},
+    {file = "mypy-1.7.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e81ffd120ee24959b449b647c4b2fbfcf8acf3465e082b8d58fd6c4c2b27e46"},
+    {file = "mypy-1.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:f29386804c3577c83d76520abf18cfcd7d68264c7e431c5907d250ab502658ee"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:87c076c174e2c7ef8ab416c4e252d94c08cd4980a10967754f91571070bf5fbe"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6cb8d5f6d0fcd9e708bb190b224089e45902cacef6f6915481806b0c77f7786d"},
+    {file = "mypy-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d93e76c2256aa50d9c82a88e2f569232e9862c9982095f6d54e13509f01222fc"},
+    {file = "mypy-1.7.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cddee95dea7990e2215576fae95f6b78a8c12f4c089d7e4367564704e99118d3"},
+    {file = "mypy-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:d01921dbd691c4061a3e2ecdbfbfad029410c5c2b1ee88946bf45c62c6c91210"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:185cff9b9a7fec1f9f7d8352dff8a4c713b2e3eea9c6c4b5ff7f0edf46b91e41"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7a7b1e399c47b18feb6f8ad4a3eef3813e28c1e871ea7d4ea5d444b2ac03c418"},
+    {file = "mypy-1.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc9fe455ad58a20ec68599139ed1113b21f977b536a91b42bef3ffed5cce7391"},
+    {file = "mypy-1.7.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d0fa29919d2e720c8dbaf07d5578f93d7b313c3e9954c8ec05b6d83da592e5d9"},
+    {file = "mypy-1.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b53655a295c1ed1af9e96b462a736bf083adba7b314ae775563e3fb4e6795f5"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c1b06b4b109e342f7dccc9efda965fc3970a604db70f8560ddfdee7ef19afb05"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bf7a2f0a6907f231d5e41adba1a82d7d88cf1f61a70335889412dec99feeb0f8"},
+    {file = "mypy-1.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:551d4a0cdcbd1d2cccdcc7cb516bb4ae888794929f5b040bb51aae1846062901"},
+    {file = "mypy-1.7.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:55d28d7963bef00c330cb6461db80b0b72afe2f3c4e2963c99517cf06454e665"},
+    {file = "mypy-1.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:870bd1ffc8a5862e593185a4c169804f2744112b4a7c55b93eb50f48e7a77010"},
+    {file = "mypy-1.7.0-py3-none-any.whl", hash = "sha256:96650d9a4c651bc2a4991cf46f100973f656d69edc7faf91844e87fe627f7e96"},
+    {file = "mypy-1.7.0.tar.gz", hash = "sha256:1e280b5697202efa698372d2f39e9a6713a0395a756b1c6bd48995f8d72690dc"},
 ]
 
 [package.dependencies]
@@ -283,6 +283,7 @@ typing-extensions = ">=4.1.0"
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
 install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -364,71 +364,50 @@ files = [
 
 [[package]]
 name = "pandas"
-version = "2.1.2"
+version = "1.5.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "pandas-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:24057459f19db9ebb02984c6fdd164a970b31a95f38e4a49cf7615b36a1b532c"},
-    {file = "pandas-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6cf8fcc8a63d333970b950a7331a30544cf59b1a97baf0a7409e09eafc1ac38"},
-    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ae6ffbd9d614c20d028c7117ee911fc4e266b4dca2065d5c5909e401f8ff683"},
-    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff794eeb7883c5aefb1ed572e7ff533ae779f6c6277849eab9e77986e352688"},
-    {file = "pandas-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02954e285e8e2f4006b6f22be6f0df1f1c3c97adbb7ed211c6b483426f20d5c8"},
-    {file = "pandas-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:5b40c9f494e1f27588c369b9e4a6ca19cd924b3a0e1ef9ef1a8e30a07a438f43"},
-    {file = "pandas-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08d287b68fd28906a94564f15118a7ca8c242e50ae7f8bd91130c362b2108a81"},
-    {file = "pandas-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bbd98dcdcd32f408947afdb3f7434fade6edd408c3077bbce7bd840d654d92c6"},
-    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e90c95abb3285d06f6e4feedafc134306a8eced93cb78e08cf50e224d5ce22e2"},
-    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52867d69a54e71666cd184b04e839cff7dfc8ed0cd6b936995117fdae8790b69"},
-    {file = "pandas-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8d0382645ede2fde352da2a885aac28ec37d38587864c0689b4b2361d17b1d4c"},
-    {file = "pandas-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:65177d1c519b55e5b7f094c660ed357bb7d86e799686bb71653b8a4803d8ff0d"},
-    {file = "pandas-2.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5aa6b86802e8cf7716bf4b4b5a3c99b12d34e9c6a9d06dad254447a620437931"},
-    {file = "pandas-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d594e2ce51b8e0b4074e6644758865dc2bb13fd654450c1eae51201260a539f1"},
-    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3223f997b6d2ebf9c010260cf3d889848a93f5d22bb4d14cd32638b3d8bba7ad"},
-    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4944dc004ca6cc701dfa19afb8bdb26ad36b9bed5bcec617d2a11e9cae6902"},
-    {file = "pandas-2.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3f76280ce8ec216dde336e55b2b82e883401cf466da0fe3be317c03fb8ee7c7d"},
-    {file = "pandas-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:7ad20d24acf3a0042512b7e8d8fdc2e827126ed519d6bd1ed8e6c14ec8a2c813"},
-    {file = "pandas-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:021f09c15e1381e202d95d4a21ece8e7f2bf1388b6d7e9cae09dfe27bd2043d1"},
-    {file = "pandas-2.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7f12b2de0060b0b858cfec0016e7d980ae5bae455a1746bfcc70929100ee633"},
-    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c166b9bb27c1715bed94495d9598a7f02950b4749dba9349c1dd2cbf10729d"},
-    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25c9976c17311388fcd953cb3d0697999b2205333f4e11e669d90ff8d830d429"},
-    {file = "pandas-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:851b5afbb0d62f6129ae891b533aa508cc357d5892c240c91933d945fff15731"},
-    {file = "pandas-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:e78507adcc730533619de07bfdd1c62b2918a68cd4419ea386e28abf7f6a1e5c"},
-    {file = "pandas-2.1.2.tar.gz", hash = "sha256:52897edc2774d2779fbeb6880d2cfb305daa0b1a29c16b91f531a18918a6e0f3"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572"},
+    {file = "pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354"},
+    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23"},
+    {file = "pandas-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6973549c01ca91ec96199e940495219c887ea815b2083722821f1d7abfa2b4dc"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c39a8da13cede5adcd3be1182883aea1c925476f4e84b2807a46e2775306305d"},
+    {file = "pandas-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e474390e60ed609cec869b0da796ad94f420bb057d86784191eefc62b65819ae"},
+    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f2b952406a1588ad4cad5b3f55f520e82e902388a6d5a4a91baa8d38d23c7f6"},
+    {file = "pandas-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:bc4c368f42b551bf72fac35c5128963a171b40dce866fb066540eeaf46faa003"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9842b6f4b8479e41968eced654487258ed81df7d1c9b7b870ceea24ed9459b31"},
+    {file = "pandas-1.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fbcb19d6fceb9e946b3e23258757c7b225ba450990d9ed63ccceeb8cae609f7"},
+    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:565fa34a5434d38e9d250af3c12ff931abaf88050551d9fbcdfafca50d62babf"},
+    {file = "pandas-1.5.3-cp38-cp38-win32.whl", hash = "sha256:87bd9c03da1ac870a6d2c8902a0e1fd4267ca00f13bc494c9e5a9020920e1d51"},
+    {file = "pandas-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:41179ce559943d83a9b4bbacb736b04c928b095b5f25dd2b7389eda08f46f373"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c74a62747864ed568f5a82a49a23a8d7fe171d0c69038b38cedf0976831296fa"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee"},
+    {file = "pandas-1.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a50d9a4336a9621cab7b8eb3fb11adb82de58f9b91d84c2cd526576b881a0c5a"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd05f7783b3274aa206a1af06f0ceed3f9b412cf665b7247eacd83be41cf7bf0"},
+    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f69c4029613de47816b1bb30ff5ac778686688751a5e9c99ad8c7031f6508e5"},
+    {file = "pandas-1.5.3-cp39-cp39-win32.whl", hash = "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a"},
+    {file = "pandas-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9"},
+    {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
 ]
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
-python-dateutil = ">=2.8.2"
+python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
-tzdata = ">=2022.1"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.6)", "SQLAlchemy (>=1.4.36)", "beautifulsoup4 (>=4.11.1)", "bottleneck (>=1.3.4)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=0.8.1)", "fsspec (>=2022.05.0)", "gcsfs (>=2022.05.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.8.0)", "matplotlib (>=3.6.1)", "numba (>=0.55.2)", "numexpr (>=2.8.0)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pandas-gbq (>=0.17.5)", "psycopg2 (>=2.9.3)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.5)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "pyxlsb (>=1.0.9)", "qtpy (>=2.2.0)", "s3fs (>=2022.05.0)", "scipy (>=1.8.1)", "tables (>=3.7.0)", "tabulate (>=0.8.10)", "xarray (>=2022.03.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)", "zstandard (>=0.17.0)"]
-aws = ["s3fs (>=2022.05.0)"]
-clipboard = ["PyQt5 (>=5.15.6)", "qtpy (>=2.2.0)"]
-compression = ["zstandard (>=0.17.0)"]
-computation = ["scipy (>=1.8.1)", "xarray (>=2022.03.0)"]
-consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
-excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pyxlsb (>=1.0.9)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)"]
-feather = ["pyarrow (>=7.0.0)"]
-fss = ["fsspec (>=2022.05.0)"]
-gcp = ["gcsfs (>=2022.05.0)", "pandas-gbq (>=0.17.5)"]
-hdf5 = ["tables (>=3.7.0)"]
-html = ["beautifulsoup4 (>=4.11.1)", "html5lib (>=1.1)", "lxml (>=4.8.0)"]
-mysql = ["SQLAlchemy (>=1.4.36)", "pymysql (>=1.0.2)"]
-output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.8.10)"]
-parquet = ["pyarrow (>=7.0.0)"]
-performance = ["bottleneck (>=1.3.4)", "numba (>=0.55.2)", "numexpr (>=2.8.0)"]
-plot = ["matplotlib (>=3.6.1)"]
-postgresql = ["SQLAlchemy (>=1.4.36)", "psycopg2 (>=2.9.3)"]
-spss = ["pyreadstat (>=1.1.5)"]
-sql-other = ["SQLAlchemy (>=1.4.36)"]
-test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
-xml = ["lxml (>=4.8.0)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pathspec"
@@ -663,17 +642,6 @@ files = [
 ]
 
 [[package]]
-name = "tzdata"
-version = "2023.3"
-description = "Provider of IANA time zone data"
-optional = false
-python-versions = ">=2"
-files = [
-    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
-    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
-]
-
-[[package]]
 name = "virtualenv"
 version = "20.24.6"
 description = "Virtual Python Environment builder"
@@ -696,4 +664,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "b9a402af953a1fe96386a05d71fe055bf6303486f8fdf813ba252716155ea84d"
+content-hash = "c9891a487a2d3caf8a34303a762ca18bc4c8b70edf404df031dc75d0ab2ed530"

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -82,7 +82,7 @@ def left_join(
 
     res.drop("_merge", axis=1, inplace=True)
 
-    return res if not res.empty else None
+    return pd.DataFrame(res) if not res.empty else None
 
 
 def inner_join(
@@ -251,7 +251,9 @@ def _nested_select(
             for i, nesting in enumerate(nesting_list):  # type: ignore
                 if nesting:
                     cname = parsed_col_list[i]
-                    res[cname] = res[cname].apply(p.get(nesting))
+                    # Prevents `SettingWithCopyWarning`, ref: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
+                    res = res.copy()
+                    res.loc[:, cname] = res[cname].apply(p.get(nesting))
         # Rename columns to match exact original strings
         res.columns = orig_col_list
         # Post-processing checks

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -1,3 +1,5 @@
+import re
+from collections import defaultdict
 from typing import Any, Iterable
 
 import pandas as pd
@@ -5,6 +7,8 @@ import pandas as pd
 import pydian.partials as p
 
 from .lib.types import ApplyFunc, ConditionalCheck
+
+REGEX_COMMA_EXCLUDE_BRACKETS = r",(?![^{}]*\})"
 
 
 def select(
@@ -132,10 +136,10 @@ def insert(
 
 def alter(
     target: pd.DataFrame,
-    overwrite_cols: dict[str, list[Any]] | None = None,
-    add_cols: dict[str, list[Any]] | None = None,
-    na_default: Any = pd.NA,
     drop_cols: str | list[str] | None = None,
+    overwrite_cols: dict[str, pd.Series | list[Any]] | None = None,
+    add_cols: dict[str | tuple[str, int], pd.Series | list[Any]] | None = None,
+    na_default: Any = pd.NA,
     consume: bool = False,
 ) -> pd.DataFrame | None:
     """
@@ -148,6 +152,10 @@ def alter(
     - `drop_cols` should be comma-delimited or provide the list of columns
     - `overwrite_cols` should replace existing columns with provided data (up to that point)
     - `add_cols` should map the new column name to initial data (missing values will use `na_default`)
+
+    # TODO: add "resort", e.g. {"colName": newPositionInt, "colName1": "<-colName2", "colName3": "colName4->", "colName5": "<~>colName6"}
+    # TODO: add "extract", e.g. `->` and `+>` conventions from `select`
+    # TODO: accept pd.Series and overwrite entire column, or accept a DataFrame and overwrite subset
     """
     _check_assumptions(target)
     res = target
@@ -166,20 +174,38 @@ def alter(
             # Expect columns smaller than existing df
             if len(cdata) > n_rows:
                 return None
-            n_new_rows = len(cdata)
-            res.loc[0:n_new_rows, cname] = cdata
+            match cdata:
+                case list():
+                    n_new_rows = len(cdata)
+                    res.loc[0:n_new_rows, cname] = cdata
+                case pd.Series():
+                    # Drop old column, then reinsert to  prev spot
+                    # NOTE: Assumes pd.Series should be exact -- e.g. including name
+                    cidx = res.columns.get_loc(cname)
+                    res.drop(columns=[cname], inplace=True)
+                    new_cname = cdata.name
+                    res.insert(cidx, new_cname, cdata)
     if add_cols:
         if not isinstance(add_cols, dict):
             raise ValueError(f"`add_cols` should be a dict, got: {type(add_cols)}")
-        for cname, cdata in add_cols.items():
+        for cname, cdata in add_cols.items():  # type: ignore
+            # Default to end if adding
+            new_idx = len(res.columns)
+            if isinstance(cname, tuple):
+                cname, new_idx = cname
             # Prevent overwriting an existing column on accident
             if cname in target.columns:
                 return None
             # Expect columns smaller than existing df
             if len(cdata) > n_rows:
                 return None
-            cdata.extend([na_default] * (n_rows - len(cdata)))
-            res[cname] = cdata
+            match cdata:
+                case list():
+                    if len(cdata) < n_rows:
+                        cdata.extend([na_default] * (n_rows - len(cdata)))
+                    res[cname] = cdata
+                case pd.Series():
+                    res.insert(new_idx, cdata.name, cdata)
     if consume:
         target.drop(columns=target.columns, inplace=True)
     return res
@@ -223,39 +249,28 @@ def _nested_select(
     source: pd.DataFrame, key: str, default: Any, consume: bool
 ) -> pd.DataFrame | Any:
     res = None
-    # Get operations from key
+
+    # Extract query from key (if present)
     key = key.replace(" ", "")
     query = None
     if "~" in key:
         key, query = key.split("~")
         query = query.removeprefix("[").removesuffix("]")
-    # Get columns from syntax
-    parsed_col_list = key.split(",")
-    orig_col_list = parsed_col_list.copy()
-    # For each column, check if more nesting is used
-    nesting_list: list[str | None] = []
-    for i, c in enumerate(parsed_col_list):
-        if "." in c:
-            cname, nesting = c.split(".", maxsplit=1)
-            parsed_col_list[i] = cname
-            nesting_list.append(nesting)
-        else:
-            nesting_list.append(None)
+
+    # Extract columns from syntax
+    # NOTE: `parsed_col_list` starts with exact user-provided string, then
+    #        gets updated in `_generate_nesting_list` to exclude nesting (so matches colname)
+    parsed_col_list = re.split(REGEX_COMMA_EXCLUDE_BRACKETS, key)
+    nesting_list = _generate_nesting_list(parsed_col_list)
+
+    # Handle "*" case
+    # TODO: Handle "*" with other items, e.g. `"*, a -> {b, c}`?
     if parsed_col_list == ["*"]:
         parsed_col_list = source.columns
-        orig_col_list = source.columns
+
     try:
         res = source.query(query)[parsed_col_list] if query else source[parsed_col_list]
-        # Apply nesting if applicable
-        if any(nesting_list):
-            for i, nesting in enumerate(nesting_list):  # type: ignore
-                if nesting:
-                    cname = parsed_col_list[i]
-                    # Prevents `SettingWithCopyWarning`, ref: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
-                    res = res.copy()
-                    res.loc[:, cname] = res[cname].apply(p.get(nesting))
-        # Rename columns to match exact original strings
-        res.columns = orig_col_list
+        res = _apply_nesting_list(res, nesting_list, parsed_col_list)
         # Post-processing checks
         if res.empty:
             res = default
@@ -264,4 +279,127 @@ def _nested_select(
             source.drop(columns=parsed_col_list, inplace=True)
     except KeyError:
         res = default
+
+    return res
+
+
+def _apply_nesting_list(
+    source: pd.DataFrame,
+    nesting_list: list[str | tuple[bool, list[str] | dict[str, str]] | None],
+    parsed_col_list: list[str],
+) -> pd.DataFrame:
+    # Prevents `SettingWithCopyWarning`, ref: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
+    # TODO: does this hog too much extra memory?
+    res = source.copy()
+
+    # Apply nesting if applicable
+    col_idx_to_del: list[int] = []
+    col_to_add: defaultdict[int, list[tuple[bool, pd.Series]]] = defaultdict(list)
+    if any(nesting_list):
+        for i, nesting in enumerate(nesting_list):  # type: ignore
+            cname = parsed_col_list[i]
+            match nesting:
+                case str():
+                    s: pd.Series = res[cname].apply(p.get(nesting))
+                    s.name = f"{cname}.{nesting}"
+                    res = alter(res, overwrite_cols={cname: s})
+                case tuple():
+                    keep_col, cobj = nesting
+                    if not keep_col:
+                        col_idx_to_del.append(i)
+                    if isinstance(cobj, list):
+                        for nkey in cobj:
+                            s: pd.Series = res.loc[:, cname].apply(p.get(nkey))  # type: ignore
+                            s.name = f"{cname}.{nkey}"
+                            col_to_add[i].append((keep_col, s))
+                    elif isinstance(cobj, dict):
+                        for new_name, nkey in cobj.items():
+                            s: pd.Series = res.loc[:, cname].apply(p.get(nkey))  # type: ignore
+                            s.name = new_name
+                            col_to_add[i].append((keep_col, s))
+                case None:
+                    continue
+
+    # Do `tuple` case procecssing
+    if col_idx_to_del:
+        res.drop(columns=res.columns[col_idx_to_del], inplace=True)
+    if col_to_add:
+        bump_idx = 0
+        for idx, vlist in col_to_add.items():
+            # FYI: inserts at the front, so add extra 1 if we kept the original column
+            for kcbool, s in vlist:
+                res.insert(idx + bump_idx + int(kcbool), s.name, s.values)
+                bump_idx += 1
+
+    return res
+
+
+def _generate_nesting_list(
+    parsed_col_list: list[str],
+) -> list[str | tuple[bool, list[str] | dict[str, str]] | None]:
+    """
+    Return whether a specific column index should get nesting logic applied
+
+    For each column, check if:
+      1. Column should be extracted and consumed (`->`)
+      2. Column should be extracted and kept (`+>`)
+      3. Column should be nested into and consumed (exactly once)
+
+    Order matters!
+
+    Not a pure function -- assume `parsed_col_list` might be modified
+    """
+    nesting_list: list[str | tuple[bool, list[str] | dict[str, str]] | None] = []
+    # for i, c in enumerate(parsed_col_list):
+    for i, c in enumerate(parsed_col_list):
+        # 1. extract, and consume original
+        # 2. extract, and keep original
+        if ("->" in c) or ("+>" in c):
+            keep_col = "+>" in c
+            splitter = "+>" if keep_col else "->"
+            cname, content = c.split(splitter)
+            cobj = _extract_list_or_dict(content)
+            if cobj:
+                # NOTE: Remove the nesting from `parsed_col_list` for later processing
+                parsed_col_list[i] = cname
+                nesting_list.append((keep_col, cobj))
+            else:
+                nesting_list.append(None)
+        # 3. nesting, consume and replace
+        elif "." in c:
+            cname, nesting = c.split(".", maxsplit=1)
+            # NOTE: Remove the nesting from `parsed_col_list` for later processing
+            parsed_col_list[i] = cname
+            nesting_list.append(nesting)
+        else:
+            nesting_list.append(None)
+    return nesting_list
+
+
+def _extract_list_or_dict(s: str) -> list[str] | dict[str, str] | None:
+    """
+    Given a string in brackets, tries to extract into set or dict, else None.
+    """
+    # Check if the string starts and ends with curly braces
+    if not (s.startswith("{") and s.endswith("}")):
+        return None
+    # Remove the curly braces and strip whitespace
+    content = s[1:-1].strip()
+    res: list[str] | dict[str, str] | None = None
+    # Determine if the string is a dictionary (contains ':') or a set
+    if ":" in content:
+        # Handle dictionary
+        try:
+            # Split the string into key-value pairs
+            items = content.split(",")
+            dict_result = {}
+            for item in items:
+                key, value = item.split(":")
+                dict_result[key.strip().strip("'").strip('"')] = value.strip().strip("'").strip('"')
+            res = dict_result
+        except ValueError:
+            res = None
+    else:
+        # Handle set (return as a list to preserve ordering)
+        res = [x.strip().strip("'").strip('"') for x in content.split(",")]
     return res

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -57,7 +57,7 @@ def select(
 
 
 def left_join(
-    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str], consume: bool = False
+    first: pd.DataFrame, second: pd.DataFrame, on: str | list[str]
 ) -> pd.DataFrame | None:
     """
     Applies a left join

--- a/pydian/dataframes.py
+++ b/pydian/dataframes.py
@@ -155,7 +155,6 @@ def alter(
 
     # TODO: add "resort", e.g. {"colName": newPositionInt, "colName1": "<-colName2", "colName3": "colName4->", "colName5": "<~>colName6"}
     # TODO: add "extract", e.g. `->` and `+>` conventions from `select`
-    # TODO: accept pd.Series and overwrite entire column, or accept a DataFrame and overwrite subset
     """
     _check_assumptions(target)
     res = target

--- a/pydian/dicts.py
+++ b/pydian/dicts.py
@@ -40,8 +40,11 @@ def get(
     # For `strict`, prefer Mapper setting or take local setting
     strict = (mapper_state.strict if mapper_state else None) or strict
 
-    res = _nested_get(source, key, default)
-    _enforce_strict(res, strict, key, source)
+    if source:
+        res = _nested_get(source, key, default)
+        _enforce_strict(res, strict, key, source)
+    else:
+        res = default
 
     if flatten and isinstance(res, list):
         res = flatten_list(res)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "pydian"
-version = "0.2.4"
+version = "0.3.0"
 description = "Library for pythonic data interchange"
 authors = ["Eric Pan <eric.pan@stanford.edu>"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 jmespath = "^1.0.1"
-pandas = "^2.1.2"
+pandas = "^1.5.1"
 
 [tool.poetry.dev-dependencies]
 black = "^23.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,8 @@ src_paths = ["pydian"]
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:pandas.*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydian"
-version = "0.3.0"
+version = "0.3.1"
 description = "Library for pythonic data interchange"
 authors = ["Eric Pan <eric.pan@stanford.edu>"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 
-def simple_list() -> list[Any]:
+def simple_nested_list() -> list[dict[str, Any]]:
     return [
         {"patient": {"id": "abc123", "active": True}},
         {"patient": {"id": "def456", "active": True}},
@@ -12,9 +12,59 @@ def simple_list() -> list[Any]:
     ]
 
 
+def deep_nested_list() -> list[dict[str, Any]]:
+    return [
+        {
+            "patient": {
+                "id": "abc123",
+                "active": True,
+                "ints": [1, 2, 3],
+                "dict": {"char": "a", "inner": {"msg": "A!"}},
+                "dicts": [
+                    {"num": 1, "text": "one", "inner": {"msg": "One!"}},
+                    {"num": 2, "text": "two", "inner": {"msg": "Two!"}},
+                ],
+            }
+        },
+        {
+            "patient": {
+                "id": "def456",
+                "active": False,
+                "ints": [4, 5, 6],
+                "dict": {"char": "b", "inner": {"msg": "B!"}},
+                "dicts": [
+                    {"num": 3, "text": "three", "inner": {"msg": "Three!"}},
+                    {"num": 4, "text": "four", "inner": {"msg": "Four!"}},
+                ],
+            }
+        },
+        {
+            "patient": {
+                "id": "ghi789",
+                "active": True,
+                "ints": [7, 8, 9],
+                "dict": {"char": "c", "inner": {"msg": "C!"}},
+                "dicts": [
+                    {"num": 5, "text": "five", "inner": {"msg": "Five!"}},
+                    {"num": 6, "text": "six", "inner": {"msg": "Six!"}},
+                ],
+            }
+        },
+        {
+            "patient": {
+                "id": "jkl101112",
+                "active": True,
+                # 'ints' is deliberately missing
+                "dict": {"char": "d", "inner": {"msg": "D!"}},
+                "dicts": [{"num": 7, "text": "seven", "inner": {"msg": "Seven!"}}],
+            }
+        },
+    ]
+
+
 @pytest.fixture(scope="function")
 def list_data() -> list[Any]:
-    return simple_list()
+    return simple_nested_list()
 
 
 @pytest.fixture(scope="function")
@@ -30,61 +80,25 @@ def simple_dataframe() -> pd.DataFrame:
 
 
 @pytest.fixture(scope="function")
+def nested_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            # Wrap in `pd.Series` to allow for different lengths, backfill with `NaN`
+            "simple_nesting": pd.Series(simple_nested_list()),  # len: 3
+            "deep_nesting": pd.Series(deep_nested_list()),  # len: 4
+            "a": pd.Series([0, 1, 2, 3, 4]),  # len: 5
+        }
+    )
+
+
+@pytest.fixture(scope="function")
 def simple_data() -> dict[str, Any]:
     return {
         "data": {"patient": {"id": "abc123", "active": True}},
-        "list_data": simple_list(),
+        "list_data": simple_nested_list(),
     }
 
 
 @pytest.fixture(scope="function")
 def nested_data() -> dict[str, Any]:
-    return {
-        "data": [
-            {
-                "patient": {
-                    "id": "abc123",
-                    "active": True,
-                    "ints": [1, 2, 3],
-                    "dict": {"char": "a", "inner": {"msg": "A!"}},
-                    "dicts": [
-                        {"num": 1, "text": "one", "inner": {"msg": "One!"}},
-                        {"num": 2, "text": "two", "inner": {"msg": "Two!"}},
-                    ],
-                }
-            },
-            {
-                "patient": {
-                    "id": "def456",
-                    "active": False,
-                    "ints": [4, 5, 6],
-                    "dict": {"char": "b", "inner": {"msg": "B!"}},
-                    "dicts": [
-                        {"num": 3, "text": "three", "inner": {"msg": "Three!"}},
-                        {"num": 4, "text": "four", "inner": {"msg": "Four!"}},
-                    ],
-                }
-            },
-            {
-                "patient": {
-                    "id": "ghi789",
-                    "active": True,
-                    "ints": [7, 8, 9],
-                    "dict": {"char": "c", "inner": {"msg": "C!"}},
-                    "dicts": [
-                        {"num": 5, "text": "five", "inner": {"msg": "Five!"}},
-                        {"num": 6, "text": "six", "inner": {"msg": "Six!"}},
-                    ],
-                }
-            },
-            {
-                "patient": {
-                    "id": "jkl101112",
-                    "active": True,
-                    # 'ints' is deliberately missing
-                    "dict": {"char": "d", "inner": {"msg": "D!"}},
-                    "dicts": [{"num": 7, "text": "seven", "inner": {"msg": "Seven!"}}],
-                }
-            },
-        ]
-    }
+    return {"data": deep_nested_list()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def deep_nested_list() -> list[dict[str, Any]]:
                 "active": True,
                 # 'ints' is deliberately missing
                 "dict": {"char": "d", "inner": {"msg": "D!"}},
+                # `dicts` is deliberately len=1 instead of len=2
                 "dicts": [{"num": 7, "text": "seven", "inner": {"msg": "Seven!"}}],
             }
         },

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -11,10 +11,10 @@ from pydian.dataframes import alter, inner_join, insert, left_join, select
 def test_select(simple_dataframe: pd.DataFrame) -> None:
     source = simple_dataframe
 
-    assert source[["a"]].equals(select(source, "a"))
-    assert source[["a", "b"]].equals(select(source, "a, b"))
-    assert source[["a", "a"]].equals(select(source, "a, a"))
-    assert source.equals(select(source, "*"))
+    pd.testing.assert_frame_equal(select(source, "a"), source[["a"]])
+    pd.testing.assert_frame_equal(source[["a", "b"]], select(source, "a, b"))
+    pd.testing.assert_frame_equal(select(source, "a, a"), source[["a", "a"]])
+    pd.testing.assert_frame_equal(select(source, "*"), source)
 
     assert select(source, "non_existant_col", apply=p.equals("thing")) is None
     assert select(source, "non_existant_col", default="thing", apply=p.equals("thing")) == True
@@ -38,32 +38,34 @@ def test_select(simple_dataframe: pd.DataFrame) -> None:
     q1 = select(source, "a ~ [a == 0]")
     q2 = select(source, "a, b, c ~ [a % 2 == 0]")
     q3_none = select(source, "non_existant_col ~ [a % 2 == 0]")
-    assert pd.DataFrame(source[source["a"] == 0]["a"]).equals(q1)
-    assert source[source["a"] % 2 == 0][["a", "b", "c"]].equals(q2)
+
+    pd.testing.assert_frame_equal(q1, pd.DataFrame(source[source["a"] == 0]["a"]))
+    pd.testing.assert_frame_equal(q2, source[source["a"] % 2 == 0][["a", "b", "c"]])
     assert q3_none is None
 
     # Replace
-    assert source.where(lambda r: r["a"] % 2 == 0, other="Test").equals(
+    pd.testing.assert_frame_equal(
         select(
             source,
             "*",
             apply=p.replace_where(lambda r: r["a"] % 2 == 0, "Test"),
-        )
+        ),
+        source.where(lambda r: r["a"] % 2 == 0, other="Test"),
     )
 
     # ORDER BY
-    assert source.sort_values("a", ascending=False).equals(
-        select(source, "*", apply=p.order_by("a", False))
+    pd.testing.assert_frame_equal(
+        select(source, "*", apply=p.order_by("a", False)), source.sort_values("a", ascending=False)
     )
 
     # GROUP BY
     assert source.groupby("a").groups == select(source, "*", apply=p.group_by("a"))
 
     # "First n"
-    assert source.head(5).equals(select(source, "*", apply=p.keep(5)))
+    pd.testing.assert_frame_equal(select(source, "*", apply=p.keep(5)), source.head(5))
 
     # Distinct
-    assert source.drop_duplicates().equals(select(source, "*", apply=p.distinct()))
+    pd.testing.assert_frame_equal(select(source, "*", apply=p.distinct()), source.drop_duplicates())
 
 
 def test_select_apply_map(simple_dataframe: pd.DataFrame) -> None:
@@ -76,7 +78,7 @@ def test_select_apply_map(simple_dataframe: pd.DataFrame) -> None:
     comp_df["b"] = comp_df["b"].apply(str.upper)
     comp_df["d"] = comp_df["d"].apply(lambda v: v is None)
 
-    assert comp_df.equals(select(source, "*", apply=apply_map))
+    pd.testing.assert_frame_equal(select(source, "*", apply=apply_map), comp_df)
 
 
 def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
@@ -85,7 +87,7 @@ def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
     source_ref = deepcopy(simple_dataframe)
 
     init_mem_usage_by_column = source.memory_usage(deep=True)
-    assert source[["a"]].equals(select(source, "a", consume=True))
+    pd.testing.assert_frame_equal(source[["a"]], select(source, "a", consume=True))
     assert source.empty == False
     assert "a" not in source.columns
     assert sum(source.memory_usage(deep=True)) < sum(init_mem_usage_by_column)
@@ -93,11 +95,11 @@ def test_select_consume(simple_dataframe: pd.DataFrame) -> None:
     # Selecting from a missing column will not consume others specified (operation failed)
     assert select(source, "a, b", consume=True) is None
     assert "b" in source.columns
-    assert source_ref["b"].equals(source["b"])
+    assert source["b"].equals(source_ref["b"])
 
     # Selecting multiple columns that are all valid
     assert source_two.equals(source_ref)
-    assert source_two[["b", "c"]].equals(select(source_two, "b, c", consume=True))
+    pd.testing.assert_frame_equal(source_two[["b", "c"]], select(source_two, "b, c", consume=True))
     assert "b" not in source_two.columns
     assert "c" not in source_two.columns
 
@@ -110,7 +112,7 @@ def test_nested_select(nested_dataframe: pd.DataFrame) -> None:
         )
     )
     single_nesting_expected.columns = ["simple_nesting.patient.id"]
-    assert single_nesting_expected.equals(single_nesting_res)
+    pd.testing.assert_frame_equal(single_nesting_res, single_nesting_expected)
 
 
 def test_left_join(simple_dataframe: pd.DataFrame) -> None:
@@ -142,7 +144,7 @@ def test_left_join(simple_dataframe: pd.DataFrame) -> None:
     expected = expected.merge(df_right, on="a", how="left")
     result = left_join(source, df_right, on="a")
 
-    assert expected.equals(result)
+    pd.testing.assert_frame_equal(result, expected)
 
     # Join resulting in empty DataFrame
     df_empty_right = pd.DataFrame(columns=["a", "e"])


### PR DESCRIPTION
Closes #23 

## Background

- Nested data (like json) is often stored in tables
- Wrangling nested json from tables is hard
- Currently pydian goes `json -> json`, and traditionally need to go `table -> json -> table`.  Here can we go `table -> table` and nest the json and abstract-away the middle step?

## Design (high-level)
- In `select`, check for the nesting syntax (`.`) and use the pydian `get` if so


## Other notes
